### PR TITLE
Add Slack + Github actions and fix CODEOWNERS file

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,46 @@
+name: Notify Applications team on "Ready for review" PRs
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  notify-slack:
+    if: github.event.label.name == 'Ready for review'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send notification to Slack
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "text": "*Pull Request Ready for Review!*",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rocket: *PR Title*: '"\"${PR_TITLE}\""'"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Author*: '"\"${PR_AUTHOR}\""'"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*PR Link*: <'"\"${PR_URL}\"'|Click here to review>"
+                }
+              }
+            ]
+          }' \
+          ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -35,33 +35,3 @@ jobs:
             ]
           }" \
           $SLACK_WEBHOOK_URL
-
-  remove-label-on-approval:
-    if: github.event.review.state == 'approved'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Remove label from PR
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
-            const labelToRemove = 'Ready for review';
-            const labels = pullRequest.labels.map(label => label.name);
-
-            if (labels.includes(labelToRemove)) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: labelToRemove
-              });
-              console.log(`Removed label: ${labelToRemove}`);
-            } else {
-              console.log(`Label ${labelToRemove} not found on PR.`);
-            }

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -12,12 +12,14 @@ jobs:
     steps:
       - name: Send notification to Slack
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
-
-          echo "Webhook URL starts with: ${SLACK_WEBHOOK_URL::5}" # For debugging, ensure the URL is correct
+          PR_ID="${{ github.event.pull_request.id }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_ADDITIONS="${{ github.event.pull_request.additions }}"
+          PR_DELETIONS="${{ github.event.pull_request.deletions }}"
+          REPO_NAME="${{ github.event.repository.name }}"
 
           curl -X POST -H 'Content-type: application/json' \
           --data "{
@@ -27,14 +29,7 @@ jobs:
                 \"type\": \"section\",
                 \"text\": {
                   \"type\": \"mrkdwn\",
-                  \"text\": \":rocket: *PR Title*: ${PR_TITLE}\"
-                }
-              },
-              {
-                \"type\": \"section\",
-                \"text\": {
-                  \"type\": \"mrkdwn\",
-                  \"text\": \"*Author*: ${PR_AUTHOR}\"
+                  \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: +${PR_ADDITIONS} -${PR_DELETIONS}  ${REPO_NAME}#${PR_ID}: ${PR_TITLE}\"
                 }
               },
               {

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Test Secret Access
-        run:
-
       - name: Send notification to Slack
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -29,7 +29,7 @@ jobs:
                 \"type\": \"section\",
                 \"text\": {
                   \"type\": \"mrkdwn\",
-                  \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
+                  \"text\": \"@applications-team ::rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
                 }
               }
             ]

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -47,3 +47,33 @@ jobs:
             ]
           }" \
           $SLACK_WEBHOOK_URL
+
+  remove-label-on-approval:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Remove label from PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const labelToRemove = 'Ready for review';
+            const labels = pullRequest.labels.map(label => label.name);
+
+            if (labels.includes(labelToRemove)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: labelToRemove
+              });
+              console.log(`Removed label: ${labelToRemove}`);
+            } else {
+              console.log(`Label ${labelToRemove} not found on PR.`);
+            }

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Send notification to Slack
         run: |
           SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
-          PR_ID="${{ github.event.pull_request.id }}"
+          PR_NR="${{ github.event.pull_request.number }}"
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_TITLE="${{ github.event.pull_request.title }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
@@ -29,7 +29,7 @@ jobs:
                 \"type\": \"section\",
                 \"text\": {
                   \"type\": \"mrkdwn\",
-                  \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: +${PR_ADDITIONS} -${PR_DELETIONS}  ${REPO_NAME}#${PR_ID}: ${PR_TITLE}\"
+                  \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
                 }
               },
               {

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Test Secret Access
+        run:
+          echo "Webhook URL starts with: ${SLACK_WEBHOOK_URL::5}"
       - name: Send notification to Slack
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -16,33 +16,34 @@ jobs:
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
-          
-          echo "Webhook URL starts with: ${SLACK_WEBHOOK_URL::5}" 
+
+          echo "Webhook URL starts with: ${SLACK_WEBHOOK_URL::5}" # For debugging, ensure the URL is correct
+
           curl -X POST -H 'Content-type: application/json' \
-          --data '{
-            "text": "*Pull Request Ready for Review!*",
-            "blocks": [
+          --data "{
+            \"text\": \"*Pull Request Ready for Review!*\", 
+            \"blocks\": [
               {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rocket: *PR Title*: '"\"${PR_TITLE}\""'"
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \":rocket: *PR Title*: ${PR_TITLE}\"
                 }
               },
               {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Author*: '"\"${PR_AUTHOR}\""'"
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \"*Author*: ${PR_AUTHOR}\"
                 }
               },
               {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*PR Link*: <'"\"${PR_URL}\"'|Click here to review>"
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \"*PR Link*: <${PR_URL}|Click here to review>\"
                 }
               }
             ]
-          }' \
+          }" \
           $SLACK_WEBHOOK_URL

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -45,3 +45,4 @@ jobs:
               }
             ]
           }' \
+          ${SLACK_WEBHOOK_URL}

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -29,7 +29,7 @@ jobs:
                 \"type\": \"section\",
                 \"text\": {
                   \"type\": \"mrkdwn\",
-                  \"text\": \"@applications-team ::rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
+                  \"text\": \"@applications-team: :rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
                 }
               }
             ]

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -45,4 +45,4 @@ jobs:
               }
             ]
           }' \
-          ${SLACK_WEBHOOK_URL}
+          $SLACK_WEBHOOK_URL

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -12,13 +12,15 @@ jobs:
     steps:
       - name: Test Secret Access
         run:
-          echo "Webhook URL starts with: ${SLACK_WEBHOOK_URL::5}"
+
       - name: Send notification to Slack
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          
+          echo "Webhook URL starts with: ${SLACK_WEBHOOK_URL::5}" 
           curl -X POST -H 'Content-type: application/json' \
           --data '{
             "text": "*Pull Request Ready for Review!*",
@@ -46,4 +48,3 @@ jobs:
               }
             ]
           }' \
-          ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -31,13 +31,6 @@ jobs:
                   \"type\": \"mrkdwn\",
                   \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
                 }
-              },
-              {
-                \"type\": \"section\",
-                \"text\": {
-                  \"type\": \"mrkdwn\",
-                  \"text\": \"*PR Link*: <${PR_URL}|Click here to review>\"
-                }
               }
             ]
           }" \

--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -1,0 +1,67 @@
+name: Periodic PR Reminders
+
+on:
+  schedule:
+    - cron: '*/2 * * * *'  # Every 2 minutes
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Send reminders for PRs with "Ready for review"
+        run: |
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          
+          # Fetch PRs with "Ready for review" label
+          PRS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?labels=Ready%20for%20review&state=open&per_page=100")
+          PR_COUNT=$(echo $PRS | jq '. | length')
+          
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "No PRs with 'Ready for review' label found."
+            exit 0
+          fi
+
+          # Iterate over each PR and send a reminder
+          for row in $(echo "${PRS}" | jq -r '.[] | @base64'); do
+            _jq() {
+              echo ${row} | base64 --decode | jq -r ${1}
+            }
+            PR_TITLE=$(_jq '.title')
+            PR_URL=$(_jq '.html_url')
+            PR_AUTHOR=$(_jq '.user.login')
+
+            # Send Slack notification
+            curl -X POST -H 'Content-type: application/json' \
+            --data "{
+              \"text\": \"*Reminder:* Pull Request '${PR_TITLE}' is still in review. Please take action!\",
+              \"blocks\": [
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \":warning: *PR Title*: ${PR_TITLE}\"
+                  }
+                },
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"*Author*: ${PR_AUTHOR}\"
+                  }
+                },
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"*PR Link*: <${PR_URL}|Click here to review>\"
+                  }
+                }
+              ]
+            }" \
+            $SLACK_WEBHOOK_URL
+          done

--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -2,7 +2,7 @@ name: Periodic PR Reminders
 
 on:
   schedule:
-    - cron: '*/2 * * * *'  # Every 2 minutes
+    - cron: '0 */3 * * *' # Runs every 3 hours
 
 jobs:
   reminder:
@@ -31,34 +31,30 @@ jobs:
             _jq() {
               echo ${row} | base64 --decode | jq -r ${1}
             }
+            PR_NR=$(_jq '.number')
             PR_TITLE=$(_jq '.title')
             PR_URL=$(_jq '.html_url')
             PR_AUTHOR=$(_jq '.user.login')
+            PR_ADDITIONS=$(_jq '.additions')
+            PR_DELETIONS=$(_jq '.deletions')
 
             # Send Slack notification
             curl -X POST -H 'Content-type: application/json' \
             --data "{
-              \"text\": \"*Reminder:* Pull Request '${PR_TITLE}' is still in review. Please take action!\",
+              \"text\": \"*Reminder:* Pull Request '${PR_TITLE}' is still in review, please take a look!\",
               \"blocks\": [
                 {
                   \"type\": \"section\",
                   \"text\": {
                     \"type\": \"mrkdwn\",
-                    \"text\": \":warning: *PR Title*: ${PR_TITLE}\"
+                    \"text\": \":warning: *Reminder:* Pull Request <${PR_URL}|#${PR_NR}> is still in review, please take a look!\"
                   }
                 },
                 {
                   \"type\": \"section\",
                   \"text\": {
                     \"type\": \"mrkdwn\",
-                    \"text\": \"*Author*: ${PR_AUTHOR}\"
-                  }
-                },
-                {
-                  \"type\": \"section\",
-                  \"text\": {
-                    \"type\": \"mrkdwn\",
-                    \"text\": \"*PR Link*: <${PR_URL}|Click here to review>\"
+                    \"text\": \":rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
                   }
                 }
               ]

--- a/.github/workflows/remove-label-when-approved.yml
+++ b/.github/workflows/remove-label-when-approved.yml
@@ -1,0 +1,39 @@
+name: Remove "Ready for review" label on PR approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  remove-label-on-approval:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Remove "Ready for review" label from PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const labelToRemove = 'Ready for review';
+            const labels = pullRequest.labels.map(label => label.name);
+
+            if (labels.includes(labelToRemove)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: labelToRemove
+              });
+              console.log(`Removed label: ${labelToRemove}`);
+            } else {
+              console.log(`Label ${labelToRemove} not found on PR.`);
+            }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,11 +3,19 @@
 # build and test workflows for pull requests and pipelines.  As such, it is expected
 # that this repository will have many owners and some shared areas (reusable macros, etc.)
 #
+# The syntax is the same as defined in
+# https://help.github.com/articles/about-codeowners/
+#
+# Important Rules:
+# 1. The last matching pattern in this file takes precedence
+#
+# 2. Only domains (github team) own code, not individuals
+#    see list at https://github.com/orgs/datarobot/teams
+#
 # Please see DataRobot repo ./tools/code_owners.py tool to find which particular file
 # or directory is owned by what domain.
 #
 # Default owners for everything in the repo.
 # Unless a later match takes precedence, these groups will be requested for
 # review when someone opens a pull request.
-
-/                                                @datarobot/applications
+*   @kideh88


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

We (maintainers) should be aware of any PRs that are waiting for reviews

## Changes

- Add workflow for sending slack message when 'Ready for review' label has been added
- Add workflow for reminding about pending PR reviews every 3 hrs (AFAIK will not be active until it is merged to main)
- Remove label once PR has been approved
- Update the CODEOWNERS file

