### PR TITLE
[Yolo-bug] Show footer citations when no other info data is available

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,4 @@
 # Default owners for everything in the repo.
 # Unless a later match takes precedence, these groups will be requested for
 # review when someone opens a pull request.
-*   @kideh88
+*   @datarobot-oss/applications-oss

--- a/src/components.py
+++ b/src/components.py
@@ -111,11 +111,13 @@ def response_info_footer(message):
     custom_metric_id = st.session_state.custom_metric_id
 
     info_section_data = get_info_section_data(message)
-    if len(info_section_data) > 0:
+    has_info_data = len(info_section_data) > 0
+    if has_info_data or citations is not None:
         with sal.columns('chat-message-footer'):
             col0, col1 = st.columns([0.7, 0.3], vertical_alignment="center")
 
-            render_info_section(info_section_data, col0)
+            if has_info_data:
+                render_info_section(info_section_data, col0)
 
             with sal.column('justify-end', 'flex-row', container=col1):
                 if custom_metric_id is not None:

--- a/template_info.json
+++ b/template_info.json
@@ -15,5 +15,5 @@
    },
    "templateType":"customApplicationTemplate",
    "templateSubType":"customApplicationTemplate",
-   "executionEnvironmentName":"[DataRobot] Python 3.12 Streamlit"
+   "executionEnvironmentName":"[DataRobot] Python 3.12"
 }


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Currently the footer will hide If there is no meta info. Show it as long as the citations are available 

### Summary of Changes

- Fix codeowners/env name
- Add citations/info_data conditions