### PR TITLE
[APP-3386] Change param type to deployment

### DIFF
--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -2,4 +2,4 @@ runtimeParameterDefinitions:
 - fieldName: CUSTOM_METRIC_ID
   type: string
 - fieldName: DEPLOYMENT_ID
-  type: string
+  type: deployment

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "10.2.2"
+         "releaseTag": "10.2.3"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Make the deployment selection easier by using the `deployment` param type 
