### PR TITLE
[APP-3393] Change hardcoded resultText to use target_name from deployment

### DIFF
--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -51,6 +51,7 @@ def make_prediction(init_message):
     deployment_association_id_settings = deployment.get_association_id_settings()
     association_id_names = deployment_association_id_settings.get("column_names")
     prompt_column_name = deployment.model.get('prompt', "promptText")
+    result_column_name = deployment.model.get('target_name', "resultText")
 
     data_tuples = [
         (prompt_column_name, prompt),
@@ -85,7 +86,7 @@ def make_prediction(init_message):
         for message in st.session_state.messages:
             if message['id'] == prompt_id:
                 if prediction and not prediction_error:
-                    message['result'] = prediction['resultText']
+                    message['result'] = prediction[result_column_name]
                     message['execution_status'] = STATUS_COMPLETED
                     message["citations"] = [{'text': doc['page_content'],
                                              'source': doc['metadata']['source'],

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "10.2.3"
+         "releaseTag": "10.2.4"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

We hardcoded the resultText column name, instead use the deployment target_name
