### PR TITLE
[APP-3402] Force prompt to be string using quotes

### DIFF
--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -46,7 +46,8 @@ def submit_metric(message, value):
 # TODO: Split non request code to util 'prepare request data'
 def make_prediction(init_message):
     deployment = get_deployment()
-    prompt = init_message['prompt']
+    # Force prompt to be string using quotes, simply setting the type will get re-cast in transit
+    prompt = f"'{init_message['prompt']}'"
     prompt_id = init_message['id']
     deployment_association_id_settings = deployment.get_association_id_settings()
     association_id_names = deployment_association_id_settings.get("column_names")


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Sending integers as prompt cause an error as they seem to be inferred to wrong type  

### Summary of Changes

- Force quotes on the prompt value 

![image](https://github.com/user-attachments/assets/1aa1ef91-f2bf-4c4e-abb2-d967d1a846e9)
