### PR TITLE
[APP-3408] Add error for missing deployment_id and not found deployment

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -8,8 +8,10 @@ from constants import (APP_LOGO, APP_EMPTY_CHAT_IMAGE, APP_EMPTY_CHAT_IMAGE_WIDT
                        I18N_CITATION_BUTTON, I18N_CITATION_DIALOG_TITLE, I18N_CITATION_KEY_ANSWER,
                        I18N_CITATION_KEY_PROMPT, I18N_CITATION_KEY_CITATION, I18N_CITATION_SOURCE_PAGE,
                        I18N_SPLASH_TITLE, I18N_SPLASH_TEXT, I18N_LOADING_MESSAGE, I18N_ACCESSIBILITY_LABEL_LLM,
-                       STATUS_ERROR, STATUS_INITIATE, I18N_ACCESSIBILITY_LABEL_YOU)
+                       STATUS_ERROR, STATUS_INITIATE, I18N_ACCESSIBILITY_LABEL_YOU, I18N_NO_DEPLOYMENT_FOUND,
+                       I18N_NO_DEPLOYMENT_ID)
 from dr_requests import submit_metric, make_prediction, get_application_info
+from utils import get_deployment
 
 
 def render_app_header():
@@ -191,9 +193,17 @@ def render_response_message(message):
 @st.experimental_fragment
 def render_empty_chat():
     empty_chat = st.container()
-    empty_chat.image(APP_EMPTY_CHAT_IMAGE, width=APP_EMPTY_CHAT_IMAGE_WIDTH)
-    with sal.text('empty-chat-header', container=empty_chat):
-        empty_chat.text(I18N_SPLASH_TITLE)
-    if I18N_SPLASH_TEXT:
+    deployment = get_deployment()
+
+    if st.session_state.deployment_id and deployment:
+        empty_chat.image(APP_EMPTY_CHAT_IMAGE, width=APP_EMPTY_CHAT_IMAGE_WIDTH)
+        with sal.text('empty-chat-header', container=empty_chat):
+            empty_chat.text(I18N_SPLASH_TITLE)
+        if I18N_SPLASH_TEXT:
+            with sal.text('empty-chat-text', container=empty_chat):
+                empty_chat.text(I18N_SPLASH_TEXT)
+    else:
+        error_text = I18N_NO_DEPLOYMENT_FOUND.format(
+            st.session_state.deployment_id) if st.session_state.deployment_id and not deployment else I18N_NO_DEPLOYMENT_ID
         with sal.text('empty-chat-text', container=empty_chat):
-            empty_chat.text(I18N_SPLASH_TEXT)
+            empty_chat.error(error_text)

--- a/src/constants.py
+++ b/src/constants.py
@@ -56,6 +56,8 @@ I18N_SHARE_DIALOG_TITLE = "Share Application"
 I18N_DIALOG_CLOSE_BUTTON = "Close"
 I18N_ACCESSIBILITY_LABEL_YOU = 'you'  # Name is not shown in the UI but is only set as an accessibility label
 I18N_ACCESSIBILITY_LABEL_LLM = 'ai'  # Name is not shown in the UI but is only set as an accessibility label
+I18N_NO_DEPLOYMENT_ID = "Required environment variable `DEPLOYMENT_ID` is not defined. Set the variable and rebuild the app"
+I18N_NO_DEPLOYMENT_FOUND = "Could not find deployment with given id: {}"
 
 STATUS_INITIATE = 'INITIATE'
 STATUS_ERROR = 'ERROR'

--- a/src/constants.py
+++ b/src/constants.py
@@ -56,7 +56,7 @@ I18N_SHARE_DIALOG_TITLE = "Share Application"
 I18N_DIALOG_CLOSE_BUTTON = "Close"
 I18N_ACCESSIBILITY_LABEL_YOU = 'you'  # Name is not shown in the UI but is only set as an accessibility label
 I18N_ACCESSIBILITY_LABEL_LLM = 'ai'  # Name is not shown in the UI but is only set as an accessibility label
-I18N_NO_DEPLOYMENT_ID = "Required environment variable `DEPLOYMENT_ID` is not defined. Set the variable and rebuild the app"
+I18N_NO_DEPLOYMENT_ID = "Required environment variable `DEPLOYMENT_ID` is not defined. Set the variable and rebuild the application"
 I18N_NO_DEPLOYMENT_FOUND = "Could not find deployment with given id: {}"
 
 STATUS_INITIATE = 'INITIATE'

--- a/src/qa_chat_bot.py
+++ b/src/qa_chat_bot.py
@@ -6,7 +6,7 @@ from streamlit_sal import sal_stylesheet
 
 from components import render_prompt_message, render_response_message, render_empty_chat, render_app_header
 from constants import *
-from utils import add_new_prompt_message, initiate_session_state
+from utils import add_new_prompt_message, initiate_session_state, get_deployment
 
 # Basic application page configuration, modify values in `constants.py`
 st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_LAYOUT,
@@ -18,6 +18,7 @@ def start_streamlit():
 
     # Setup DR client
     set_client(Client(token=st.session_state.token, endpoint=st.session_state.endpoint))
+    has_valid_deployment = st.session_state.deployment_id and get_deployment()
 
     # Wraps the application with a SAL stylesheet so elements within it can be customized
     with sal_stylesheet():
@@ -29,8 +30,9 @@ def start_streamlit():
                 st.subheader('Sidebar Title')
                 st.write('Add your sidebar content here')
 
-        if prompt := st.chat_input(I18N_INPUT_PLACEHOLDER):
-            add_new_prompt_message(prompt)
+        if has_valid_deployment:
+            if prompt := st.chat_input(I18N_INPUT_PLACEHOLDER):
+                add_new_prompt_message(prompt)
 
         if len(st.session_state.messages) > 0:
             # Render all chat messages from this session on every app rerun

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,10 +1,11 @@
+import logging
 import os
 import uuid
 from typing import Any
 
 import requests
 import streamlit as st
-from datarobot import Deployment
+from datarobot import Deployment, AppPlatformError
 
 from constants import USER_ID, USER_AVATAR, USER_DISPLAY_NAME, LLM_DISPLAY_NAME, LLM_AVATAR, STATUS_INITIATE
 
@@ -25,7 +26,11 @@ def raise_datarobot_error_for_status(response):
 
 @st.cache_data(show_spinner=False)
 def get_deployment():
-    return Deployment.get(st.session_state.deployment_id)
+    try:
+        return Deployment.get(st.session_state.deployment_id)
+    except AppPlatformError:
+        logging.error('Failed to get deployment')
+        return None
 
 
 def initiate_session_state():


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

There is currently no guidance and user friendly errors when deployment id is missing or the deployment was not found

### Summary of Changes

- Add error for both cases

![no dpeloy](https://github.com/user-attachments/assets/76b04aae-2a81-4529-9a3c-546c5ed05b07)
![image](https://github.com/user-attachments/assets/8213e0eb-3325-4c23-abb3-6d1469cb38ba)


