### PR TITLE
[APP-3461] Add override URL for on-prem / ST SAAS

### DIFF
--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -1,7 +1,9 @@
+import os
 import json
 import logging
 import sys
 from datetime import datetime
+from typing import Optional
 
 import pandas as pd
 import requests
@@ -13,6 +15,16 @@ from constants import CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS, MAX_PREDICTION_INPUT
     STATUS_COMPLETED
 from utils import get_deployment, raise_datarobot_error_for_status, process_citations, rename_dataframe_columns
 
+
+def prediction_server_override_url() -> Optional[str]:
+    """
+    Because of the way internal networking is set up for on-prem and ST SAAS networks,
+    we need to use the service URL instead of the external URL.
+    """
+    if os.environ.get("DATAROBOT_ENDPOINT") == 'http://datarobot-nginx/api/v2/':
+        return 'http://datarobot-prediction-server:80/predApi/v1.0/'
+    else:
+        return None
 
 def submit_metric(message, value):
     deployment = get_deployment()
@@ -75,7 +87,7 @@ def make_prediction(init_message):
     processed_citations = None
 
     try:
-        result_df, response_headers = predict(deployment, input_df)
+        result_df, response_headers = predict(deployment, input_df, prediction_endpoint=prediction_server_override_url())
         processed_df = rename_dataframe_columns(result_df)
         prediction = processed_df.to_dict(orient="records")[0]
         processed_citations = process_citations(prediction)


### PR DESCRIPTION
For our On-Prem and ST SAAS customers in 10.2 we will need to override the prediction server URL. The clusters we have 
 there have very bespoke network policies, and at the moment there is limited egress. 

I chose to determine whether we were on-prem or not by testing the public API URL for two reasons:
1. If the app needs to send requests to the  `datarobot-nginx` service instead of the public API, it probably needs to send requests to via the`datarobot-prediction-server` service URL. 
2. If we change the network policies in the future and are free to access the prediction server through the app's regular host, and we adjust the `DATAROBOT_ENDPOINT` inside the logic which controls app environment provisioning, we  won't break this template. 

I tested this in the EKS regression environment
<img width="1712" alt="Screenshot 2024-10-29 at 11 03 41 AM" src="https://github.com/user-attachments/assets/e1613eb4-421d-43cd-9d23-e0ec8a40d0c0">

