### PR TITLE
[APP-3335] Fix predict columns when assoc id is same as prompt column

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ our [DataRobot Docs](https://docs.datarobot.com/en/docs/workbench/nxt-registry/n
 
 ## Feedback custom metric
 
-Feedback buttons on LLM responses will only appear if the `CUSTOM_METRIC_ID` environment variable has been set. Below is an example of a metric for thumbs up and down, you can add it by navigating to **Console -> Deployment -> Monitoring ->Custom metrics** .
+The application uses the association ID from the deployment to match the LLM response with the given feedback. Navigate
+to **Console -> Deployment -> Settings -> Custom metrics** and set the `Association ID` to `message_id`. 
+
+Feedback buttons on LLM responses will only appear if the `CUSTOM_METRIC_ID` environment variable has been set.
+Below is an example of a metric for thumbs up and down, you can add it by navigating to **Console -> Deployment ->
+Monitoring ->Custom metrics** .
 
 - Name: Feedback
 - Metric ID: -- Copy this for the runtime parameter --
@@ -95,5 +100,11 @@ Feedback buttons on LLM responses will only appear if the `CUSTOM_METRIC_ID` env
 - Baseline: 0
 - Aggregation type: Average
 - Higher is better
- 
-![Custom Metric Example](https://github.com/datarobot-oss/qa-app-streamlit/blob/main/assets/custom_metric_example.png) 
+
+![Custom Metric Example](https://github.com/datarobot-oss/qa-app-streamlit/blob/main/assets/custom_metric_example.png)
+
+## Troubleshooting
+
+| Error                                                              | Solution                                                                                                                              |
+|:-------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------|
+| `Could not find root directory. Did you run 'streamlit-sal init'?` | Make sure that all application src files have been uploaded, including dotfiles: `.streamlit-sal` (file) and `.streamlit` (directory) |

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,6 +3,9 @@ API_URL = '{base_url}/predApi/v1.0/deployments/{deployment_id}/predictions'  # n
 # Don't change this. It is enforced server-side too.
 MAX_PREDICTION_INPUT_SIZE_BYTES = 52428800  # 50 MB
 
+DEFAULT_PROMPT_COLUMN_NAME = 'promptText'
+DEFAULT_RESULT_COLUMN_NAME = 'resultText'
+
 # Timeouts
 CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS = 60
 PREDICTIONS_TIMEOUT_SECONDS = 60

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -10,8 +10,9 @@ from datarobot.models.deployment import CustomMetric
 from datarobot_predict.deployment import predict
 
 from constants import CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS, MAX_PREDICTION_INPUT_SIZE_BYTES, STATUS_ERROR, \
-    STATUS_COMPLETED
-from utils import get_deployment, raise_datarobot_error_for_status, process_citations, rename_dataframe_columns
+    STATUS_COMPLETED, DEFAULT_PROMPT_COLUMN_NAME, DEFAULT_RESULT_COLUMN_NAME
+from utils import get_deployment, raise_datarobot_error_for_status, process_citations, rename_dataframe_columns, \
+    get_association_id_column_name
 
 
 def submit_metric(message, value):
@@ -49,15 +50,13 @@ def make_prediction(init_message):
     # Force prompt to be string using quotes, simply setting the type will get re-cast in transit
     prompt = f"'{init_message['prompt']}'"
     prompt_id = init_message['id']
-    deployment_association_id_settings = deployment.get_association_id_settings()
-    association_id_names = deployment_association_id_settings.get("column_names")
-    prompt_column_name = deployment.model.get('prompt', "promptText")
-    result_column_name = deployment.model.get('target_name', "resultText")
+    association_id_column_name = get_association_id_column_name()
+    prompt_column_name = deployment.model.get('prompt', DEFAULT_PROMPT_COLUMN_NAME)
+    result_column_name = deployment.model.get('target_name', DEFAULT_RESULT_COLUMN_NAME)
 
     data_tuples = [
+        (association_id_column_name, prompt_id) if association_id_column_name is not None else None,
         (prompt_column_name, prompt),
-        (association_id_names[0], prompt_id) if association_id_names is not None else None,
-        ('response', '') if association_id_names is not None else None,
     ]
     data = dict(filter(lambda item: item is not None, data_tuples))
     data_size = sys.getsizeof(data)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from typing import Any
+from typing import cast, Dict, Any
 
 import requests
 import streamlit as st
@@ -31,6 +31,16 @@ def get_deployment():
     except AppPlatformError:
         logging.error('Failed to get deployment')
         return None
+
+
+@st.cache_data(show_spinner=False)
+def get_association_id_column_name():
+    deployment = get_deployment()
+
+    # The library typing sets the return value as <string>, but it actually returns a <dict>. Cast it here
+    deployment_association_id_settings = cast(Dict[str, Any], deployment.get_association_id_settings())
+    association_id_names = deployment_association_id_settings.get("column_names")
+    return association_id_names[0]
 
 
 def initiate_session_state():


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

If Deployment association ID is set to `promptText` it will overwrite the actual prompt and break the app. Fix it and add better README

### Summary of Changes
- Refactor column name getter
- Set promptText after assoc id to avoid overwriting it even with misconfigured deployment
- Add better readme section for custom metric / assoc id
- Add troubleshooting section with common errors and solutions

