### PR TITLE
[APP-3463] Fix unexpected LaTex formatting by escaping $ symbol

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -11,7 +11,7 @@ from constants import (APP_LOGO, APP_EMPTY_CHAT_IMAGE, APP_EMPTY_CHAT_IMAGE_WIDT
                        STATUS_ERROR, STATUS_INITIATE, I18N_ACCESSIBILITY_LABEL_YOU, I18N_NO_DEPLOYMENT_FOUND,
                        I18N_NO_DEPLOYMENT_ID)
 from dr_requests import submit_metric, make_prediction, get_application_info
-from utils import get_deployment
+from utils import get_deployment, escape_result_text
 
 
 def render_app_header():
@@ -186,7 +186,8 @@ def render_response_message(message):
             elif message['execution_status'] == STATUS_ERROR:
                 st.error(message['error_message'], icon="🚨")
             else:
-                st.write(message['result'])
+                escaped_text = escape_result_text(message['result'])
+                st.write(escaped_text)
                 response_info_footer(message)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -102,3 +102,8 @@ def rename_dataframe_columns(df):
     # Apply the function to all column names
     df.columns = [clean_column_name(col) for col in df.columns]
     return df
+
+
+def escape_result_text(text):
+    # Avoids unexpected LaTex formatting on LLM response ($...$)
+    return text.replace("$", r"\$")


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

LLM responses with multiple $ characters would be shown as LaTex format. Escape $ symbols to avoid it

![image](https://github.com/user-attachments/assets/2094baf4-1a4c-409c-86a9-1bf65c8d4ee0)

