### PR TITLE
[APP-3468] QA chat template: Rename exec env 3.12 App Base and bump version

### DIFF
--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "10.2.4"
+         "releaseTag": "10.2.5"
       },
       "previewImage": "qa-app-preview.png"
    },

--- a/template_info.json
+++ b/template_info.json
@@ -15,5 +15,5 @@
    },
    "templateType": "customApplicationTemplate",
    "templateSubType": "customApplicationTemplate",
-   "executionEnvironmentName": "[DataRobot] Python 3.12"
+   "executionEnvironmentName": "[DataRobot] Python 3.12 Applications Base"
 }


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

The base execution environment is getting renamed. Update the template_info and bump the version