### PR TITLE
[APP-3490] Fix error when assoc id is not set

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -11,7 +11,7 @@ from constants import (APP_LOGO, APP_EMPTY_CHAT_IMAGE, APP_EMPTY_CHAT_IMAGE_WIDT
                        STATUS_ERROR, STATUS_INITIATE, I18N_ACCESSIBILITY_LABEL_YOU, I18N_NO_DEPLOYMENT_FOUND,
                        I18N_NO_DEPLOYMENT_ID)
 from dr_requests import submit_metric, make_prediction, get_application_info
-from utils import get_deployment, escape_result_text
+from utils import get_deployment, escape_result_text, get_association_id_column_name
 
 
 def render_app_header():
@@ -115,6 +115,7 @@ def response_info_footer(message):
     feedback = message['feedback_value']
     citations = message.get('citations', None)
     custom_metric_id = st.session_state.custom_metric_id
+    association_id = get_association_id_column_name()
 
     info_section_data = get_info_section_data(message)
     has_info_data = len(info_section_data) > 0
@@ -126,7 +127,7 @@ def response_info_footer(message):
                 render_info_section(info_section_data, col0)
 
             with sal.column('justify-end', 'flex-row', container=col1):
-                if custom_metric_id is not None:
+                if custom_metric_id is not None and association_id is not None:
                     btn_up_icon_class = 'feedback-up-icon-active' if feedback == 1 else 'feedback-up-icon'
                     with sal.button('feedback-button', btn_up_icon_class, container=col1):
                         # Uses thin blank “ ” (U+2009) to be visible

--- a/src/utils.py
+++ b/src/utils.py
@@ -40,7 +40,7 @@ def get_association_id_column_name():
     # The library typing sets the return value as <string>, but it actually returns a <dict>. Cast it here
     deployment_association_id_settings = cast(Dict[str, Any], deployment.get_association_id_settings())
     association_id_names = deployment_association_id_settings.get("column_names")
-    return association_id_names[0]
+    return association_id_names[0] if association_id_names else None
 
 
 def initiate_session_state():

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "10.2.4"
+         "releaseTag": "10.2.6"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

The association ID is considered an optional setting for the LLM deployment that is used in the Q&A app.
It should not give any exceptions when not set

### Summary of Changes

- Fix get_association_id_column_name function
- Hide feedback buttons when assoc id is not set
- Bump version

![image](https://github.com/user-attachments/assets/d9a9283d-a4b1-45f7-8a10-e86d434e8f05)

