### PR TITLE
[APP-3527] Detect Chat API support from deployment capabilities

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -6,9 +6,15 @@ MAX_PREDICTION_INPUT_SIZE_BYTES = 52428800  # 50 MB
 DEFAULT_PROMPT_COLUMN_NAME = 'promptText'
 DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 
+# Chat API
+CHAT_CAPABILITIES_KEY = 'supports_chat_api'
+# To disable chat api even when deployment supports it
+FORCE_DISABLE_CHAT_API = False
+
 # Timeouts
 CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS = 60
 PREDICTIONS_TIMEOUT_SECONDS = 60
+CAPABILITIES_TIMEOUT_SECONDS = 20
 
 # Set asset path or remote url
 APP_LOGO = './assets/dr-logo-for-dark-bg.svg'

--- a/src/qa_chat_bot.py
+++ b/src/qa_chat_bot.py
@@ -6,7 +6,8 @@ from streamlit_sal import sal_stylesheet
 
 from components import render_prompt_message, render_response_message, render_empty_chat, render_app_header
 from constants import *
-from utils import add_new_prompt_message, initiate_session_state, get_deployment
+from dr_requests import get_has_chat_api_support
+from utils import add_new_prompt_message, initiate_session_state, set_chat_api_session_state, get_deployment
 
 # Basic application page configuration, modify values in `constants.py`
 st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_LAYOUT,
@@ -15,6 +16,10 @@ st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_L
 
 def start_streamlit():
     initiate_session_state()
+    is_chat_api_enabled = get_has_chat_api_support(deployment_id=st.session_state.deployment_id,
+                                       token=st.session_state.token,
+                                       endpoint=st.session_state.endpoint) if FORCE_DISABLE_CHAT_API == False else False
+    set_chat_api_session_state(is_chat_api_enabled)
 
     # Setup DR client
     set_client(Client(token=st.session_state.token, endpoint=st.session_state.endpoint))

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,6 +62,11 @@ def initiate_session_state():
         st.session_state.messages = []
 
 
+def set_chat_api_session_state(is_chat_api_enabled):
+    if 'is_chat_api_enabled' not in st.session_state or st.session_state.is_chat_api_enabled != is_chat_api_enabled:
+        st.session_state.is_chat_api_enabled = is_chat_api_enabled
+
+
 def add_new_prompt_message(prompt):
     deployment = get_deployment()
     new_prompt_id = str(uuid.uuid4())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,16 @@ def mock_deployment_api(
         },
     )
 
+    responses.get(
+        f"{datarobot_endpoint}/deployments/{deployment_id}/capabilities/",
+        json={'data': [{'messages': ['Retraining is not supported.'],
+                        'name': 'supports_retraining',
+                        'supported': False},
+                       {'messages': [],
+                        'name': 'supports_chat_api',
+                        'supported': True}]},
+    )
+
     responses.post(
         feedback_endpoint,
         json=None,

--- a/tests/test_qa_chat_bot.py
+++ b/tests/test_qa_chat_bot.py
@@ -1,6 +1,6 @@
 import json
-import sys
 import os
+import sys
 from collections import namedtuple
 from unittest.mock import patch
 
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
     "mock_set_env",
     "mock_app_info_api",
     "mock_version_api",
+    "mock_deployment_api",
     "app_id"
 )
 @patch('constants.I18N_APP_NAME', 'Application Test')
@@ -45,6 +46,7 @@ def test_empty_chat_app():
         assert at.text[0].value == 'What would you like to know?'
         assert at.text[1].value == 'Ask me anything!'
         assert at.chat_input[0].placeholder == 'Send your question'
+        assert at.session_state.is_chat_api_enabled == True
 
 
 @responses.activate


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

In preparation for Chat API we need to detect whether the deployment even supports it. 

### Summary of Changes

- Add deployment capabilities call
- Check for chat api support