### PR TITLE
[APP-3526] Refactor messages and meta state in preparation for Chat API

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -10,7 +10,7 @@ from constants import (APP_LOGO, APP_EMPTY_CHAT_IMAGE, APP_EMPTY_CHAT_IMAGE_WIDT
                        I18N_SPLASH_TITLE, I18N_SPLASH_TEXT, I18N_LOADING_MESSAGE, I18N_ACCESSIBILITY_LABEL_LLM,
                        ROLE_USER, I18N_ACCESSIBILITY_LABEL_YOU, I18N_NO_DEPLOYMENT_FOUND,
                        I18N_NO_DEPLOYMENT_ID, LLM_AVATAR, LLM_DISPLAY_NAME, USER_AVATAR, USER_DISPLAY_NAME,
-                       ROLE_ASSISTANT)
+                       ROLE_ASSISTANT, STATUS_ERROR)
 from dr_requests import submit_metric, send_predict_request, get_application_info
 from utils import get_deployment, escape_result_text, get_association_id_column_name, get_message_by_role
 
@@ -177,6 +177,7 @@ def render_message(message):
     msg_acc_name = I18N_ACCESSIBILITY_LABEL_YOU if role == ROLE_USER else I18N_ACCESSIBILITY_LABEL_LLM
     msg_name = USER_DISPLAY_NAME if role == ROLE_USER else LLM_DISPLAY_NAME
     msg_avatar = USER_AVATAR if role == ROLE_USER else LLM_AVATAR
+    meta_data = st.session_state.messages_meta[msg_id]
 
     # Render the message within a fragment, that way st.rerun() will only affect this container and not the whole app
     with sal.chat_message():
@@ -186,9 +187,12 @@ def render_message(message):
             if role == ROLE_USER:
                 st.markdown(content)
             else:
-                escaped_text = escape_result_text(message['content'])
-                st.write(escaped_text)
-                response_info_footer(msg_id)
+                if 'status' in meta_data and meta_data['status'] == STATUS_ERROR:
+                    st.error(meta_data['error_message'], icon="🚨")
+                else:
+                    escaped_text = escape_result_text(message['content'])
+                    st.write(escaped_text)
+                    response_info_footer(msg_id)
 
 
 @st.experimental_fragment

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,8 +8,8 @@ DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 
 # Chat API
 CHAT_CAPABILITIES_KEY = 'supports_chat_api'
-# To disable chat api even when deployment supports it
-FORCE_DISABLE_CHAT_API = False
+# To disable chat api even when deployment supports it. Default set to True until there is full support
+FORCE_DISABLE_CHAT_API = True
 
 # Timeouts
 CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS = 60
@@ -36,8 +36,7 @@ USER_DISPLAY_NAME = "You"
 # Material icons codes: https://fonts.google.com/icons?icon.set=Material+Symbols&icon.style=Outlined
 USER_AVATAR = ":material/person:"
 LLM_AVATAR = ":material/smart_toy:"
-# App uses deployment model type as name unless this constant is set
-LLM_DISPLAY_NAME = None
+LLM_DISPLAY_NAME = "LLM Deployment"
 
 # Translations
 I18N_APP_NAME = "Q&A Chat Application"
@@ -68,6 +67,10 @@ I18N_ACCESSIBILITY_LABEL_LLM = 'ai'  # Name is not shown in the UI but is only s
 I18N_NO_DEPLOYMENT_ID = "Required environment variable `DEPLOYMENT_ID` is not defined. Set the variable and rebuild the application"
 I18N_NO_DEPLOYMENT_FOUND = "Could not find deployment with given id: {}"
 
-STATUS_INITIATE = 'INITIATE'
+STATUS_PENDING = 'PENDING'
 STATUS_ERROR = 'ERROR'
 STATUS_COMPLETED = 'COMPLETED'
+
+ROLE_SYSTEM = 'system'
+ROLE_USER = 'user'
+ROLE_ASSISTANT = 'assistant'

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -8,6 +8,7 @@ from typing import Optional
 import pandas as pd
 import requests
 import streamlit as st
+from datarobot import AppPlatformError
 from datarobot.models.deployment import CustomMetric
 from datarobot_predict.deployment import predict
 

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -8,7 +8,6 @@ from typing import Optional
 import pandas as pd
 import requests
 import streamlit as st
-from datarobot import AppPlatformError
 from datarobot.models.deployment import CustomMetric
 from datarobot_predict.deployment import predict
 

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import sys
-import time
 from datetime import datetime
 from typing import Optional
 

--- a/src/qa_chat_bot.py
+++ b/src/qa_chat_bot.py
@@ -17,10 +17,9 @@ st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_L
 
 def start_streamlit():
     initiate_session_state()
-    # is_chat_api_enabled = get_has_chat_api_support(deployment_id=st.session_state.deployment_id,
-    #                                    token=st.session_state.token,
-    #                                    endpoint=st.session_state.endpoint) if FORCE_DISABLE_CHAT_API == False else False
-    is_chat_api_enabled = True
+    is_chat_api_enabled = get_has_chat_api_support(deployment_id=st.session_state.deployment_id,
+                                       token=st.session_state.token,
+                                       endpoint=st.session_state.endpoint) if FORCE_DISABLE_CHAT_API == False else False
     set_chat_api_session_state(is_chat_api_enabled)
 
     # Setup DR client

--- a/src/qa_chat_bot.py
+++ b/src/qa_chat_bot.py
@@ -4,10 +4,11 @@ from datarobot import Client
 from datarobot.client import set_client
 from streamlit_sal import sal_stylesheet
 
-from components import render_prompt_message, render_response_message, render_empty_chat, render_app_header
+from components import render_empty_chat, render_app_header, render_message, render_pending_message
 from constants import *
 from dr_requests import get_has_chat_api_support
-from utils import add_new_prompt_message, initiate_session_state, set_chat_api_session_state, get_deployment
+from utils import add_new_prompt, initiate_session_state, set_chat_api_session_state, get_deployment, \
+    get_message_by_role
 
 # Basic application page configuration, modify values in `constants.py`
 st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_LAYOUT,
@@ -16,9 +17,10 @@ st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_L
 
 def start_streamlit():
     initiate_session_state()
-    is_chat_api_enabled = get_has_chat_api_support(deployment_id=st.session_state.deployment_id,
-                                       token=st.session_state.token,
-                                       endpoint=st.session_state.endpoint) if FORCE_DISABLE_CHAT_API == False else False
+    # is_chat_api_enabled = get_has_chat_api_support(deployment_id=st.session_state.deployment_id,
+    #                                    token=st.session_state.token,
+    #                                    endpoint=st.session_state.endpoint) if FORCE_DISABLE_CHAT_API == False else False
+    is_chat_api_enabled = True
     set_chat_api_session_state(is_chat_api_enabled)
 
     # Setup DR client
@@ -37,15 +39,19 @@ def start_streamlit():
 
         if has_valid_deployment:
             if prompt := st.chat_input(I18N_INPUT_PLACEHOLDER):
-                add_new_prompt_message(prompt)
+                add_new_prompt(prompt)
 
-        if len(st.session_state.messages) > 0:
+        # Ignore any system message in the conversation context
+        filtered_messages = [msg for msg in st.session_state.messages if msg["role"] != ROLE_SYSTEM]
+        if len(filtered_messages) > 0:
             # Render all chat messages from this session on every app rerun
-            for message in st.session_state.messages:
+            for message in filtered_messages:
                 # Render the prompt entered by the user in a fragment function
-                render_prompt_message(message)
-                # Render the LLM response in a fragment function
-                render_response_message(message)
+                render_message(message)
+
+            if st.session_state.pending_message_id:
+                pending_message = get_message_by_role(ROLE_USER, st.session_state.pending_message_id)
+                render_pending_message(pending_message)
         else:
             # Render the empty chat splash in a fragment.
             # The SAL container remains here to keep the upper sal_stylesheet context


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

To prepare for streaming chat api we need to refactor how we treat the conversation context and relevant meta data for each message.
The existing predict implementation should continue working as before

### Summary of Changes

- Split message role/content apart from any other meta data
- Refactor how the prediction request is made so it can be swapped with streaming request later
- Force disable chat api until it is fully implemented
