### PR TITLE
[APP-3625] Allow user to disable streaming and fix response handling

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -10,6 +10,7 @@ DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 CHAT_CAPABILITIES_KEY = 'supports_chat_api'
 # To disable chat api even when deployment supports it. Default set to True until there is full support
 FORCE_DISABLE_CHAT_API = True
+ENABLE_CHAT_API_STREAMING = False
 
 # Timeouts
 CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS = 60

--- a/src/constants.py
+++ b/src/constants.py
@@ -10,7 +10,7 @@ DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 CHAT_CAPABILITIES_KEY = 'supports_chat_api'
 # To disable chat api even when deployment supports it. Default set to True until there is full support
 FORCE_DISABLE_CHAT_API = True
-ENABLE_CHAT_API_STREAMING = False
+ENABLE_CHAT_API_STREAMING = True
 
 # Timeouts
 CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS = 60


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

User should be able to control stream on/off. We should handle both types of responses properly

### Summary of Changes

- Add new const to control streaming
- Fix response handling when stream is False
