### PR TITLE
[APP-3662] Enable Chat API by default, bump template version

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -9,7 +9,7 @@ DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 # Chat API
 CHAT_CAPABILITIES_KEY = 'supports_chat_api'
 # To disable chat api even when deployment supports it. Default set to True until there is full support
-FORCE_DISABLE_CHAT_API = True
+FORCE_DISABLE_CHAT_API = False
 ENABLE_CHAT_API_STREAMING = True
 
 # Timeouts

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.2"
+         "releaseTag": "11.0.3"
       },
       "previewImage": "qa-app-preview.png"
    },

--- a/tests/test_qa_chat_bot.py
+++ b/tests/test_qa_chat_bot.py
@@ -236,7 +236,7 @@ def test_chat_feedback_request(feedback_endpoint, model_id, is_model_specific):
 
     # Check the LLM response message
     assert at.chat_message[1].markdown[0].value == '__LLM Deployment:__'
-    assert at.chat_message[1].markdown[1].value == 'Hello! How can I assist you today?'
+    assert at.chat_message[1].markdown[1].value == 'Why did the bicycle fall over? Because it was two-tired!'
 
     msg_id = at.session_state.messages[0].get('meta_id')
     feedback_up_button = at.button(key=f"feedback-up-{msg_id}")

--- a/tests/test_qa_chat_bot.py
+++ b/tests/test_qa_chat_bot.py
@@ -47,7 +47,7 @@ def test_empty_chat_app():
         assert at.text[1].value == 'Ask me anything!'
         assert at.chat_input[0].placeholder == 'Send your question'
         # Forced Chat API to be disabled
-        assert at.session_state.is_chat_api_enabled == False
+        assert at.session_state.is_chat_api_enabled == True
 
 
 @responses.activate
@@ -58,7 +58,6 @@ def test_empty_chat_app():
     "mock_deployment_api",
     "app_id"
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_chat_api_supported_app():
     """The app loads and uses deployment capabilities to check for Chat API support"""
     at = AppTest.from_file("qa_chat_bot.py").run()
@@ -73,7 +72,6 @@ def test_chat_api_supported_app():
     "mock_deployment_chat_api_stream",
     "mock_version_api",
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_chat_send_chat_api_stream_request():
     """The app receives chat response after sending a prompt"""
     app = AppTest.from_file("qa_chat_bot.py")
@@ -124,7 +122,6 @@ def test_chat_send_chat_api_stream_request():
     "mock_deployment_chat_api",
     "mock_version_api",
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch('dr_requests.ENABLE_CHAT_API_STREAMING', False)
 def test_chat_send_chat_api_without_stream_request():
     """The app receives chat response after sending a prompt"""
@@ -174,9 +171,9 @@ def test_chat_send_chat_api_without_stream_request():
     "mock_set_env",
     "mock_app_info_api",
     "mock_deployment_api",
-    "mock_deployment_api",
     "mock_version_api",
 )
+@patch('constants.FORCE_DISABLE_CHAT_API', True)
 def test_chat_send_predict_request():
     """The app receives chat response after sending a prompt"""
     app = AppTest.from_file("qa_chat_bot.py")
@@ -224,6 +221,7 @@ def test_chat_send_predict_request():
     "mock_set_env",
     "mock_app_info_api",
     "mock_deployment_api",
+    "mock_deployment_chat_api_stream",
     "mock_version_api",
     "model_id",
     "feedback_endpoint",


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

The work for Chat API has been completed, now we can enable it by default and bump the template version

