### PR TITLE
[APP-3640] Add app name as runtime param, include existing title as default

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -4,7 +4,7 @@ import streamlit_sal as sal
 from constants import (APP_LOGO, APP_EMPTY_CHAT_IMAGE, APP_EMPTY_CHAT_IMAGE_WIDTH, I18N_APP_DESCRIPTION,
                        I18N_FORMAT_LATENCY, I18N_RESPONSE_LATENCY, I18N_RESPONSE_TOKENS,
                        I18N_FORMAT_CONFIDENCE, I18N_RESPONSE_CONFIDENCE, I18N_FORMAT_CURRENCY, I18N_RESPONSE_COST,
-                       I18N_DIALOG_CLOSE_BUTTON, I18N_SHARE_BUTTON, I18N_APP_NAME, I18N_SHARE_DIALOG_TITLE,
+                       I18N_DIALOG_CLOSE_BUTTON, I18N_SHARE_BUTTON, I18N_SHARE_DIALOG_TITLE,
                        I18N_CITATION_BUTTON, I18N_CITATION_DIALOG_TITLE, I18N_CITATION_KEY_ANSWER,
                        I18N_CITATION_KEY_PROMPT, I18N_CITATION_KEY_CITATION, I18N_CITATION_SOURCE_PAGE,
                        I18N_SPLASH_TITLE, I18N_SPLASH_TEXT, I18N_LOADING_MESSAGE, I18N_ACCESSIBILITY_LABEL_LLM,
@@ -12,12 +12,12 @@ from constants import (APP_LOGO, APP_EMPTY_CHAT_IMAGE, APP_EMPTY_CHAT_IMAGE_WIDT
                        I18N_NO_DEPLOYMENT_ID, LLM_AVATAR, LLM_DISPLAY_NAME, USER_AVATAR, USER_DISPLAY_NAME,
                        ROLE_ASSISTANT, STATUS_ERROR)
 from dr_requests import submit_metric, send_predict_request, send_chat_api_request, get_application_info
-from utils import get_deployment, escape_result_text, get_association_id_column_name, get_message_by_role
+from utils import get_deployment, get_app_name, escape_result_text, get_association_id_column_name, get_message_by_role
 
 
 def render_app_header():
     app_info = get_application_info()
-    app_name = I18N_APP_NAME
+    app_name = get_app_name()
     app_description = I18N_APP_DESCRIPTION
     external_access_enabled = app_info.get('externalAccessEnabled', False)
     app_url = app_info.get('applicationUrl', None)
@@ -89,7 +89,7 @@ def show_citations_dialog(prompt, answer, citations):
             st.rerun()
 
 
-# If your LLM response contains more meta data, you can add them here to `info_items`
+# If your LLM response contains more metadata, you can add them here to `info_items`
 def get_info_section_data(message_meta):
     info_items = []
     if message_meta.get("datarobot_latency"):

--- a/src/constants.py
+++ b/src/constants.py
@@ -40,7 +40,7 @@ LLM_AVATAR = ":material/smart_toy:"
 LLM_DISPLAY_NAME = "LLM Deployment"
 
 # Translations
-I18N_APP_NAME = "Q&A Chat Application"
+I18N_APP_NAME_DEFAULT = "Q&A Chat Application"  # Fallback name in case runtime param is not set
 I18N_APP_DESCRIPTION = ""
 
 I18N_RESPONSE_COST = "Cost"

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -1,4 +1,7 @@
 runtimeParameterDefinitions:
+- fieldName: APP_NAME
+  type: string
+  defaultValue: "Q&A Chat Application"
 - fieldName: CUSTOM_METRIC_ID
   type: string
 - fieldName: DEPLOYMENT_ID

--- a/src/qa_chat_bot.py
+++ b/src/qa_chat_bot.py
@@ -8,10 +8,10 @@ from components import render_empty_chat, render_app_header, render_message, ren
 from constants import *
 from dr_requests import get_has_chat_api_support
 from utils import add_new_prompt, initiate_session_state, set_chat_api_session_state, get_deployment, \
-    get_message_by_role
+    get_message_by_role, get_app_name
 
 # Basic application page configuration, modify values in `constants.py`
-st.set_page_config(page_title=I18N_APP_NAME, page_icon=APP_FAVICON, layout=APP_LAYOUT,
+st.set_page_config(page_title=get_app_name(), page_icon=APP_FAVICON, layout=APP_LAYOUT,
                    initial_sidebar_state=SIDEBAR_DEFAULT_STATE)
 
 

--- a/src/start-app.sh
+++ b/src/start-app.sh
@@ -17,6 +17,9 @@ if [ -n "$MLOPS_RUNTIME_PARAM_CUSTOM_METRIC_ID" ]; then
 else
   export custom_metric_id="$CUSTOM_METRIC_ID"
 fi
+if [ -n "$MLOPS_RUNTIME_PARAM_APP_NAME" ]; then
+  export app_name="$MLOPS_RUNTIME_PARAM_APP_NAME"
+fi
 
 streamlit-sal compile
 streamlit run --server.port=8080 qa_chat_bot.py

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,7 +7,7 @@ import requests
 import streamlit as st
 from datarobot import Deployment, AppPlatformError
 
-from constants import STATUS_PENDING, ROLE_ASSISTANT
+from constants import STATUS_PENDING, ROLE_ASSISTANT, I18N_APP_NAME_DEFAULT
 
 
 class DataRobotPredictionError(Exception):
@@ -41,6 +41,10 @@ def get_association_id_column_name():
     deployment_association_id_settings = cast(Dict[str, Any], deployment.get_association_id_settings())
     association_id_names = deployment_association_id_settings.get("column_names")
     return association_id_names[0] if association_id_names else None
+
+
+def get_app_name():
+    return os.getenv("app_name") or I18N_APP_NAME_DEFAULT
 
 
 def initiate_session_state():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,11 @@ def custom_metric_id():
 
 
 @pytest.fixture(scope='module')
+def app_name():
+    return 'Application Test'
+
+
+@pytest.fixture(scope='module')
 def datarobot_token():
     return 'datarobot_token_' + str(ObjectId())
 
@@ -73,6 +78,16 @@ def app_base_url(
     app_id
 ):
     return f"https://test-app.datarobot.com/custom_applications/{app_id}"
+
+
+@pytest.fixture
+def mock_set_env_app_name(
+        monkeypatch,
+        app_name,
+):
+    with patch.dict(os.environ):
+        monkeypatch.setenv("app_name", app_name)
+        yield
 
 
 @pytest.fixture

--- a/tests/test_qa_chat_bot.py
+++ b/tests/test_qa_chat_bot.py
@@ -19,12 +19,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_app_name",
     "mock_app_info_api",
     "mock_version_api",
     "mock_deployment_api",
     "app_id"
 )
-@patch('constants.I18N_APP_NAME', 'Application Test')
 @patch('constants.I18N_APP_DESCRIPTION', 'A small example description')
 @patch('constants.I18N_SPLASH_TITLE', 'What would you like to know?')
 @patch('constants.I18N_SPLASH_TEXT', 'Ask me anything!')


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

For RAG assistant we would like to rename the application using runtime params