### PR TITLE
[APP-3676] Add support for system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Streaming can be disabled in the `constants.py` by setting `ENABLE_CHAT_API_STRE
 To disable the Chat API completely and continue to use the dataRobot-predict library, navigate to `constants.py`
 and set `FORCE_DISABLE_CHAT_API` to `True`.
 
+A system prompt can be configured using the `SYSTEM_PROMPT` runtime parameter. This value will overwrite any previous prompts
+set, including configuration from **Workbench > Playground**.
 
 ## App modifications
 

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -6,3 +6,5 @@ runtimeParameterDefinitions:
   type: string
 - fieldName: DEPLOYMENT_ID
   type: deployment
+- fieldName: SYSTEM_PROMPT
+  type: string

--- a/src/start-app.sh
+++ b/src/start-app.sh
@@ -20,6 +20,9 @@ fi
 if [ -n "$MLOPS_RUNTIME_PARAM_APP_NAME" ]; then
   export app_name="$MLOPS_RUNTIME_PARAM_APP_NAME"
 fi
+if [ -n "$MLOPS_RUNTIME_PARAM_SYSTEM_PROMPT" ]; then
+  export system_prompt="$MLOPS_RUNTIME_PARAM_SYSTEM_PROMPT"
+fi
 
 streamlit-sal compile
 streamlit run --server.port=8080 qa_chat_bot.py

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,7 +7,7 @@ import requests
 import streamlit as st
 from datarobot import Deployment, AppPlatformError
 
-from constants import STATUS_PENDING, ROLE_ASSISTANT, I18N_APP_NAME_DEFAULT
+from constants import STATUS_PENDING, ROLE_ASSISTANT, ROLE_SYSTEM, I18N_APP_NAME_DEFAULT
 
 
 class DataRobotPredictionError(Exception):
@@ -64,6 +64,9 @@ def initiate_session_state():
     # Create messages storage on first render
     if "messages" not in st.session_state:
         st.session_state.messages = []
+
+    if os.getenv("system_prompt") and len(st.session_state.messages) == 0:
+        st.session_state.messages.append({"role": ROLE_SYSTEM, "content": os.getenv("system_prompt")})
 
     if "messages_meta" not in st.session_state:
         st.session_state.messages_meta = {}
@@ -134,7 +137,7 @@ def escape_result_text(text):
 
 def get_message_by_role(role, meta_id):
     return next(
-        (msg for msg in st.session_state.messages if msg["meta_id"] == meta_id and msg["role"] == role), None)
+        (msg for msg in st.session_state.messages if msg.get("meta_id", None) == meta_id and msg["role"] == role), None)
 
 
 def strip_metadata_from_messages(messages):

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.3"
+         "releaseTag": "11.0.4"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Users should be able to configure a system prompt for the Chat API
Values for this parameter will override any previous prompts, even the one set in DR > Workbench > Playground


### Summary of Changes
- Add new runtime param SYSTEM_PROMPT
- Append any value as first entry in session messages
- Update readme
- Bump version