### PR TITLE
[APP-3686] Fix citations for deployments without moderation

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -79,7 +79,7 @@ def show_citations_dialog(prompt, answer, citations):
                             source_text = I18N_CITATION_SOURCE_PAGE.format(
                                 citation.get("source"),
                                 citation.get("page")
-                            ) if citation.get("page") else citation.get("source")
+                            ) if citation.get("page") is not None  else citation.get("source")
                             citation_block.caption(source_text)
                         with sal.text('citation-text', container=citation_block):
                             citation_block.text(citation.get("text"))

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -14,8 +14,8 @@ from datarobot_predict.deployment import predict
 from constants import CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS, MAX_PREDICTION_INPUT_SIZE_BYTES, STATUS_ERROR, \
     STATUS_COMPLETED, DEFAULT_PROMPT_COLUMN_NAME, DEFAULT_RESULT_COLUMN_NAME, CAPABILITIES_TIMEOUT_SECONDS, \
     CHAT_CAPABILITIES_KEY, ENABLE_CHAT_API_STREAMING
-from utils import get_deployment, raise_datarobot_error_for_status, process_citations, rename_dataframe_columns, \
-    get_association_id_column_name, strip_metadata_from_messages, set_result_message_state
+from utils import get_deployment, raise_datarobot_error_for_status, process_citations, process_predict_citations, \
+    rename_dataframe_columns, get_association_id_column_name, strip_metadata_from_messages, set_result_message_state
 
 
 @st.cache_data(show_spinner=False)
@@ -108,7 +108,7 @@ def send_predict_request(message):
         result_df, response_headers = predict(deployment, input_df, prediction_endpoint=prediction_server_override_url())
         processed_df = rename_dataframe_columns(result_df)
         prediction = processed_df.to_dict(orient="records")[0]
-        processed_citations = process_citations(prediction)
+        processed_citations = process_predict_citations(prediction)
     except Exception as exc:
         logging.error(exc)
         prediction_error = str(exc)

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -160,7 +160,7 @@ def send_chat_api_request(message):
                         message = data_json['choices'][0].get('message')
                         message_content = message.get('content')
                     result = data_json.get('datarobot_moderations', None)
-                    processed_citations = process_citations(result)
+                    processed_citations = process_citations(data_json.get('citations', []))
                 except Exception as exc:
                     logging.error(exc)
                     prediction_error = str(exc)

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -147,6 +147,9 @@ def send_chat_api_request(message):
             data_str = chunk.decode('utf-8').lstrip("data: ")
             data_json = json.loads(data_str)
 
+            if len(data_json['choices']) == 0:
+                continue
+
             # Get completion content, e.g., choices[0].delta.content
             delta_content = data_json['choices'][0]['delta'].get('content') if ENABLE_CHAT_API_STREAMING else None
             if delta_content:

--- a/src/utils.py
+++ b/src/utils.py
@@ -93,21 +93,16 @@ def add_new_prompt(prompt):
     st.session_state.pending_message_id = new_prompt_id
 
 
-def process_citations(input_dict: dict[str: Any]) -> list[dict[str: Any]]:
+def process_citations(citations: dict[str: Any]) -> list[dict[str: Any]]:
     """Processes citation data"""
     output_list = []
-    num_citations = len([k for k in input_dict.keys() if k.startswith("CITATION_CONTENT")])
 
-    for i in range(num_citations):
-        citation_content_key = f"CITATION_CONTENT_{i}"
-        citation_source_key = f"CITATION_SOURCE_{i}"
-        citation_page_key = f"CITATION_PAGE_{i}"
-
+    for citation in citations:
         citation_dict = {
-            "page_content": input_dict[citation_content_key],
+            "page_content": citation.get('content', ''),
             "metadata": {
-                "source": input_dict[citation_source_key],
-                "page": input_dict[citation_page_key]
+                "source": citation.get('metadata', {}).get('source'),
+                "page": citation.get('metadata', {}).get('page'),
             },
             "type": "Document"
         }

--- a/src/utils.py
+++ b/src/utils.py
@@ -115,6 +115,34 @@ def process_citations(citations: dict[str: Any]) -> list[dict[str: Any]]:
             in
             output_list]
 
+# Process function for the result from datarobot-predict
+def process_predict_citations(input_dict: dict[str: Any]) -> list[dict[str: Any]]:
+    """Processes citation data"""
+    output_list = []
+    num_citations = len([k for k in input_dict.keys() if k.startswith("CITATION_CONTENT")])
+
+    for i in range(num_citations):
+        citation_content_key = f"CITATION_CONTENT_{i}"
+        citation_source_key = f"CITATION_SOURCE_{i}"
+        citation_page_key = f"CITATION_PAGE_{i}"
+
+        citation_dict = {
+            "page_content": input_dict[citation_content_key],
+            "metadata": {
+                "source": input_dict[citation_source_key],
+                "page": input_dict[citation_page_key]
+            },
+            "type": "Document"
+        }
+
+        output_list.append(citation_dict)
+
+    return [{'text': doc['page_content'],
+             'source': doc['metadata']['source'],
+             'page': doc['metadata']['page']} for doc
+            in
+            output_list]
+
 
 def rename_dataframe_columns(df):
     def clean_column_name(name):

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.4"
+         "releaseTag": "11.0.5"
       },
       "previewImage": "qa-app-preview.png"
    },

--- a/tests/mocks/mock_chat_api_no_stream.json
+++ b/tests/mocks/mock_chat_api_no_stream.json
@@ -9,7 +9,29 @@
       }
     }
   ],
-  "citations": [],
+  "citations": [
+    {
+      "content": "* _Multilabel_: A generalization of multiclass that provides greater flexibility. Each observation can be associated with 0, 1, or several labels  (\"Am I looking at a cat? A dog? A cat _and_ a dog? At neither a cat _nor_ a dog?\"). Predictions report probability for each label in an observation and don't necessarily sum to 1.\n\n\t* _[Summarized categorical](histogram#summarized-categorical-features)_: A variable type used for features that host a collection of categories (for example, the count of a product by category or department). It aggregates categorical data and, while typically used for [Feature Discovery](feature-discovery/index), allows you to create the type in your dataset and use the unique visualizations.\n\n\tThe following table summarizes the feature types that support multivariate modeling:",
+      "metadata": {
+        "source": "datarobot_english_documentation/datarobot_docs|en|modeling|special-workflows|multilabel.txt",
+        "page": 0
+      }
+    },
+    {
+      "content": "Imagine you want to receive an answer to the question \"Do aliens exist?\" Your best plan to get an answer to this question is to interview a particular stranger by asking \"Did you see anything strange last night?\" If they say \"Yes\", you conclude aliens exist. If say \"No\", you conclude aliens don't exist. What's nice is that you have a friend in the army who has access to radar technology so they can determine whether an alien did or did not show up. However, you won't see your friend until next week, so for now conducting the interview experiment is your best option.",
+      "metadata": {
+        "source": "datarobot_english_documentation/datarobot_docs|en|more-info|eli5.txt",
+        "page": 0
+      }
+    },
+    {
+      "content": "The **Illustration** tab shows how summarized categorical data is represented as a feature. For example, in the below image, the **Values** column contains five summarized categorical features displayed in JSON dictionary format (selected at random), as described above.\n\n![](images/summ-cat-5.png)\n\nClick **Summary** to display a box that visualizes how categorical values appeared in their initial state, prior to being engineered as summarized categorical features.\n\n![](images/sum-cat-9.png)\n\n## Table tab {: #table-tab }\n\nThe **Table** tab, which is the default tab for [multilabel](multilabel) projects, displays a two-column table detailing counts for the top 50 most frequent label sets in the multicategorical feature.\n\n![](images/sum-cat-3.png)\n\nThe table lists each key in the **Values** column, and the respective key's count in the **Count** column.",
+      "metadata": {
+        "source": "datarobot_english_documentation/datarobot_docs|en|data|analyze-data|histogram.txt",
+        "page": 0
+      }
+    }
+  ],
   "created": 1734014841,
   "datarobot_moderations": {
     "CITATION_CONTENT_0": "* _Multilabel_: A generalization of multiclass that provides greater flexibility. Each observation can be associated with 0, 1, or several labels  (\"Am I looking at a cat? A dog? A cat _and_ a dog? At neither a cat _nor_ a dog?\"). Predictions report probability for each label in an observation and don't necessarily sum to 1.\n\n\t* _[Summarized categorical](histogram#summarized-categorical-features)_: A variable type used for features that host a collection of categories (for example, the count of a product by category or department). It aggregates categorical data and, while typically used for [Feature Discovery](feature-discovery/index), allows you to create the type in your dataset and use the unique visualizations.\n\n\tThe following table summarizes the feature types that support multivariate modeling:",

--- a/tests/mocks/mock_final_chunk.json
+++ b/tests/mocks/mock_final_chunk.json
@@ -13,7 +13,22 @@
   "created": 1734014565,
   "model": "DataRobot Moderation",
   "object": "chat.completion.chunk",
-  "citations": [],
+  "citations": [
+    {
+      "content": "* _Multilabel_: A generalization of multiclass that provides greater flexibility. Each observation can be associated with 0, 1, or several labels  (\"Am I looking at a cat? A dog? A cat _and_ a dog? At neither a cat _nor_ a dog?\"). Predictions report probability for each label in an observation and don't necessarily sum to 1.\n\n\t* _[Summarized categorical](histogram#summarized-categorical-features)_: A variable type used for features that host a collection of categories (for example, the count of a product by category or department). It aggregates categorical data and, while typically used for [Feature Discovery](feature-discovery/index), allows you to create the type in your dataset and use the unique visualizations.\n\n\tThe following table summarizes the feature types that support multivariate modeling:",
+      "metadata": {
+        "source": "datarobot_english_documentation/datarobot_docs|en|modeling|special-workflows|multilabel.txt",
+        "page": 0
+      }
+    },
+    {
+      "content": "Imagine you want to receive an answer to the question \"Do aliens exist?\" Your best plan to get an answer to this question is to interview a particular stranger by asking \"Did you see anything strange last night?\" If they say \"Yes\", you conclude aliens exist. If say \"No\", you conclude aliens don't exist. What's nice is that you have a friend in the army who has access to radar technology so they can determine whether an alien did or did not show up. However, you won't see your friend until next week, so for now conducting the interview experiment is your best option.",
+      "metadata": {
+        "source": "datarobot_english_documentation/datarobot_docs|en|more-info|eli5.txt",
+        "page": 0
+      }
+    }
+  ],
   "llm_blueprint_id": "6759612345e0837a3d481683",
   "llm_provider_guards": null,
   "prompt_vector": [],

--- a/tests/test_qa_chat_bot.py
+++ b/tests/test_qa_chat_bot.py
@@ -101,17 +101,17 @@ def test_chat_send_chat_api_stream_request():
 
     # Check citation source
     assert at.caption[
-               1].value == 'datarobot_english_documentation/datarobot_docs|en|more-info|eli5.txt'
-    assert at.caption[2].value == 'datarobot_english_documentation/datarobot_docs|en|more-info|eli5.txt'
+               1].value == 'datarobot_english_documentation/datarobot_docs|en|modeling|special-workflows|multilabel.txt - Page: 0'
+    assert at.caption[2].value == 'datarobot_english_documentation/datarobot_docs|en|more-info|eli5.txt - Page: 0'
 
     # Check citation text
-    expected_citation_text_1 = 'Troubleshooting the Worker Queue'
-    assert expected_citation_text_1 in at.text[2].value, \
-        f"Expected '{expected_citation_text_1}' to be in '{at.text[2].value}'"
+    expected_citation_text_1 = 'A generalization of multiclass that provides greater flexibility.'
+    assert expected_citation_text_1 in at.text[0].value, \
+        f"Expected '{expected_citation_text_1}' to be in '{at.text[0].value}'"
 
-    expected_citation_text_2 = 'One consideration for choosing an error metric is the expected amount of noise in the data.'
-    assert expected_citation_text_2 in at.text[3].value, \
-        f"Expected '{expected_citation_text_2}' to be in '{at.text[3].value}'"
+    expected_citation_text_2 = 'Imagine you want to receive an answer'
+    assert expected_citation_text_2 in at.text[1].value, \
+        f"Expected '{expected_citation_text_2}' to be in '{at.text[1].value}'"
 
 
 @responses.activate
@@ -153,17 +153,17 @@ def test_chat_send_chat_api_without_stream_request():
 
     # Check citation source
     assert at.caption[
-               1].value == 'datarobot_english_documentation/datarobot_docs|en|modeling|special-workflows|multilabel.txt'
-    assert at.caption[2].value == 'datarobot_english_documentation/datarobot_docs|en|more-info|eli5.txt'
+               1].value == 'datarobot_english_documentation/datarobot_docs|en|modeling|special-workflows|multilabel.txt - Page: 0'
+    assert at.caption[2].value == 'datarobot_english_documentation/datarobot_docs|en|more-info|eli5.txt - Page: 0'
 
     # Check citation text
-    expected_citation_text_1 = 'What are summarized categorical features?'
-    assert expected_citation_text_1 in at.text[2].value, \
-        f"Expected '{expected_citation_text_1}' to be in '{at.text[2].value}'"
+    expected_citation_text_1 = 'Imagine you want to receive an answer'
+    assert expected_citation_text_1 in at.text[1].value, \
+        f"Expected '{expected_citation_text_1}' to be in '{at.text[1].value}'"
 
     expected_citation_text_2 = 'The **Illustration** tab shows how summarized categorical data is represented as a feature'
-    assert expected_citation_text_2 in at.text[3].value, \
-        f"Expected '{expected_citation_text_2}' to be in '{at.text[3].value}'"
+    assert expected_citation_text_2 in at.text[2].value, \
+        f"Expected '{expected_citation_text_2}' to be in '{at.text[2].value}'"
 
 
 @responses.activate
@@ -203,8 +203,8 @@ def test_chat_send_predict_request():
 
     # Check citation source
     assert at.caption[
-               1].value == 'datarobot_english_documentation/datarobot_docs|en|get-started|gs-get-help|troubleshooting|signin-help.txt'
-    assert at.caption[2].value == 'datarobot_english_documentation/datarobot_docs|en|gen-ai|playground.txt'
+               1].value == 'datarobot_english_documentation/datarobot_docs|en|get-started|gs-get-help|troubleshooting|signin-help.txt - Page: 0'
+    assert at.caption[2].value == 'datarobot_english_documentation/datarobot_docs|en|gen-ai|playground.txt - Page: 0'
 
     # Check citation text
     expected_citation_text_1 = 'The input entered during chatting used to generate the LLM response.'


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

QA App broke for a deployment without moderations due to process citations function looking for the moderations result. Instead use the .citations on the completion

