### PR TITLE
[APP-3688] Revert chat api enable by default

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -9,7 +9,7 @@ DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 # Chat API
 CHAT_CAPABILITIES_KEY = 'supports_chat_api'
 # To disable chat api even when deployment supports it. Default set to True until there is full support
-FORCE_DISABLE_CHAT_API = False
+FORCE_DISABLE_CHAT_API = True
 ENABLE_CHAT_API_STREAMING = True
 
 # Timeouts

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -147,7 +147,7 @@ def send_chat_api_request(message):
             data_str = chunk.decode('utf-8').lstrip("data: ")
             data_json = json.loads(data_str)
 
-            if len(data_json['choices']) == 0:
+            if len(data_json.get('choices', [])) == 0:
                 continue
 
             # Get completion content, e.g., choices[0].delta.content

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.5"
+         "releaseTag": "11.0.6"
       },
       "previewImage": "qa-app-preview.png"
    },

--- a/tests/test_qa_chat_bot.py
+++ b/tests/test_qa_chat_bot.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 @patch('constants.I18N_SPLASH_TITLE', 'What would you like to know?')
 @patch('constants.I18N_SPLASH_TEXT', 'Ask me anything!')
 @patch('constants.I18N_INPUT_PLACEHOLDER', 'Send your question')
+@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_empty_chat_app():
     # Path to the CSV file relative to the test file
     current_dir = os.path.dirname(__file__)
@@ -58,6 +59,7 @@ def test_empty_chat_app():
     "mock_deployment_api",
     "app_id"
 )
+@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_chat_api_supported_app():
     """The app loads and uses deployment capabilities to check for Chat API support"""
     at = AppTest.from_file("qa_chat_bot.py").run()
@@ -72,6 +74,7 @@ def test_chat_api_supported_app():
     "mock_deployment_chat_api_stream",
     "mock_version_api",
 )
+@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_chat_send_chat_api_stream_request():
     """The app receives chat response after sending a prompt"""
     app = AppTest.from_file("qa_chat_bot.py")
@@ -122,6 +125,7 @@ def test_chat_send_chat_api_stream_request():
     "mock_deployment_chat_api",
     "mock_version_api",
 )
+@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch('dr_requests.ENABLE_CHAT_API_STREAMING', False)
 def test_chat_send_chat_api_without_stream_request():
     """The app receives chat response after sending a prompt"""
@@ -173,7 +177,6 @@ def test_chat_send_chat_api_without_stream_request():
     "mock_deployment_api",
     "mock_version_api",
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', True)
 def test_chat_send_predict_request():
     """The app receives chat response after sending a prompt"""
     app = AppTest.from_file("qa_chat_bot.py")
@@ -228,6 +231,7 @@ def test_chat_send_predict_request():
     "is_model_specific"
 )
 @pytest.mark.parametrize("is_model_specific", [True, False])
+@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_chat_feedback_request(feedback_endpoint, model_id, is_model_specific):
     """The user can submit feedback for a response"""
     app = AppTest.from_file("qa_chat_bot.py")


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

We are facing issues with some LLMs on prod. Better to revert the default enabler for now


