### PR TITLE
[APP-3754] Change chat api constants to runtime params

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ LLM Blueprints created via DataRobot's Playground now support OpenAI's Chat API.
 available via the deployment on: `<API_URL>/deployments/<deployment_id>/chat/completions`.
 Documentation for this API can be found [here](https://docs.datarobot.com/en/docs/gen-ai/genai-code/genai-chat-completion-api.html) or in [OpenAI docs](https://platform.openai.com/docs/api-reference/chat).
 
+To enable Chat API, select a deployment that supports it and set the runtime parameter `ENABLE_CHAT_API` to `True`.
+If the selected deployment does _not_ support Chat API, it will automatically fall back to use the `datarobot-predict`
+library.
+
 Streaming will soon be supported by the deployment Chat API implementation described above. Currently, streaming is only supported for GPT blueprints and the response always contains only one chunk due to the applied prompt and/or result text guards.
 
-Streaming can be enabled in the `constants.py` by setting `ENABLE_CHAT_API_STREAMING` to `True`.
-
-To disable the Chat API completely and continue to use the dataRobot-predict library, navigate to `constants.py`
-and set `FORCE_DISABLE_CHAT_API` to `True`.
+Streaming can be enabled in the runtime parameters by setting `ENABLE_CHAT_API_STREAMING` to `True`.
 
 A system prompt can be configured using the `SYSTEM_PROMPT` runtime parameter. This value will overwrite any previous prompts
 set, including configuration from **Workbench > Playground**.

--- a/src/components.py
+++ b/src/components.py
@@ -34,8 +34,7 @@ from constants import (
     USER_DISPLAY_NAME,
     ROLE_ASSISTANT,
     ROLE_USER,
-    STATUS_ERROR,
-    ENABLE_CHAT_API_STREAMING
+    STATUS_ERROR
 )
 from dr_requests import (
     submit_metric,
@@ -236,7 +235,7 @@ def render_pending_message(message):
     with sal.chat_message():
         with st.chat_message(name=I18N_ACCESSIBILITY_LABEL_LLM, avatar=LLM_AVATAR):
             st.markdown(f"__{LLM_DISPLAY_NAME}:__")
-            if st.session_state.is_chat_api_enabled and ENABLE_CHAT_API_STREAMING:
+            if st.session_state.is_chat_api_enabled and st.session_state.enable_chat_api_streaming:
                 # Immediately render any incoming streaming response
                 st.write_stream(send_chat_api_streaming_request(message))
                 # The final streaming chunk has been received now. Trigger rerun to let the render_message handle the

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,10 +8,6 @@ DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 
 # Chat API
 CHAT_CAPABILITIES_KEY = 'supports_chat_api'
-# To disable chat api even when deployment supports it. Default set to True until there is full support
-FORCE_DISABLE_CHAT_API = True
-# Currently only GPT blueprints support streaming via the Chat API
-ENABLE_CHAT_API_STREAMING = False
 
 # Timeouts
 CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS = 60

--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -8,3 +8,12 @@ runtimeParameterDefinitions:
   type: deployment
 - fieldName: SYSTEM_PROMPT
   type: string
+  description: Replaces the system prompt set in Playground
+- fieldName: ENABLE_CHAT_API
+  type: boolean
+  defaultValue: False
+  description: Use Chat API if the deployment supports it
+- fieldName: ENABLE_CHAT_API_STREAMING
+  type: boolean
+  defaultValue: False
+  description: Stream the response from Chat API

--- a/src/qa_chat_bot.py
+++ b/src/qa_chat_bot.py
@@ -19,7 +19,7 @@ def start_streamlit():
     initiate_session_state()
     is_chat_api_enabled = get_has_chat_api_support(deployment_id=st.session_state.deployment_id,
                                        token=st.session_state.token,
-                                       endpoint=st.session_state.endpoint) if FORCE_DISABLE_CHAT_API == False else False
+                                       endpoint=st.session_state.endpoint) if st.session_state.enable_chat_api else False
     set_chat_api_session_state(is_chat_api_enabled)
 
     # Setup DR client

--- a/src/start-app.sh
+++ b/src/start-app.sh
@@ -1,27 +1,29 @@
 #!/usr/bin/env bash
 echo "Starting App"
 
-export token="$DATAROBOT_API_TOKEN"
-export endpoint="$DATAROBOT_ENDPOINT"
-export app_base_url_path="$STREAMLIT_SERVER_BASE_URL_PATH"
+export TOKEN="$DATAROBOT_API_TOKEN"
+export ENDPOINT="$DATAROBOT_ENDPOINT"
+export APP_BASE_URL_PATH="$STREAMLIT_SERVER_BASE_URL_PATH"
 
 # If you have configured runtime params via DataRobots application source, the following 2 values should be set automatically.
 # Otherwise you will need to set DEPLOYMENT_ID (required) and CUSTOM_METRIC_ID (optional) manually
 if [ -n "$MLOPS_RUNTIME_PARAM_DEPLOYMENT_ID" ]; then
-  export deployment_id="$MLOPS_RUNTIME_PARAM_DEPLOYMENT_ID"
-else
-  export deployment_id="$DEPLOYMENT_ID"
+  export DEPLOYMENT_ID="$MLOPS_RUNTIME_PARAM_DEPLOYMENT_ID"
 fi
 if [ -n "$MLOPS_RUNTIME_PARAM_CUSTOM_METRIC_ID" ]; then
-  export custom_metric_id="$MLOPS_RUNTIME_PARAM_CUSTOM_METRIC_ID"
-else
-  export custom_metric_id="$CUSTOM_METRIC_ID"
+  export CUSTOM_METRIC_ID="$MLOPS_RUNTIME_PARAM_CUSTOM_METRIC_ID"
 fi
 if [ -n "$MLOPS_RUNTIME_PARAM_APP_NAME" ]; then
-  export app_name="$MLOPS_RUNTIME_PARAM_APP_NAME"
+  export APP_NAME="$MLOPS_RUNTIME_PARAM_APP_NAME"
 fi
 if [ -n "$MLOPS_RUNTIME_PARAM_SYSTEM_PROMPT" ]; then
-  export system_prompt="$MLOPS_RUNTIME_PARAM_SYSTEM_PROMPT"
+  export SYSTEM_PROMPT="$MLOPS_RUNTIME_PARAM_SYSTEM_PROMPT"
+fi
+if [ -n "$MLOPS_RUNTIME_PARAM_ENABLE_CHAT_API" ]; then
+  export ENABLE_CHAT_API="$MLOPS_RUNTIME_PARAM_ENABLE_CHAT_API"
+fi
+if [ -n "$MLOPS_RUNTIME_PARAM_ENABLE_CHAT_API_STREAMING" ]; then
+  export ENABLE_CHAT_API_STREAMING="$MLOPS_RUNTIME_PARAM_ENABLE_CHAT_API_STREAMING"
 fi
 
 streamlit-sal compile

--- a/src/utils.py
+++ b/src/utils.py
@@ -57,29 +57,34 @@ def get_association_id_column_name():
 
 
 def get_app_name():
-    return os.getenv("app_name") or I18N_APP_NAME_DEFAULT
+    return os.getenv("APP_NAME") or I18N_APP_NAME_DEFAULT
 
 
 def initiate_session_state():
     # Env variables
     if 'token' not in st.session_state:
-        st.session_state.token = os.getenv("token")
+        st.session_state.token = os.getenv("TOKEN")
     if 'endpoint' not in st.session_state:
-        st.session_state.endpoint = os.getenv("endpoint")
+        st.session_state.endpoint = os.getenv("ENDPOINT")
     if 'custom_metric_id' not in st.session_state:
-        st.session_state.custom_metric_id = os.getenv("custom_metric_id") or None
+        st.session_state.custom_metric_id = os.getenv("CUSTOM_METRIC_ID")
     if 'deployment_id' not in st.session_state:
-        st.session_state.deployment_id = os.getenv("deployment_id") or None
+        st.session_state.deployment_id = os.getenv("DEPLOYMENT_ID")
     if 'app_id' not in st.session_state:
-        app_base_url_path = os.getenv("app_base_url_path", None)
+        app_base_url_path = os.getenv("APP_BASE_URL_PATH")
         st.session_state.app_id = app_base_url_path.split('/')[-1].strip() if app_base_url_path else None
+
+    if 'enable_chat_api' not in st.session_state:
+        st.session_state.enable_chat_api = os.getenv("ENABLE_CHAT_API", 'False').lower() == 'true'
+    if 'enable_chat_api_streaming' not in st.session_state:
+        st.session_state.enable_chat_api_streaming = os.getenv("ENABLE_CHAT_API_STREAMING", 'False').lower() == 'true'
 
     # Create messages storage on first render
     if "messages" not in st.session_state:
         st.session_state.messages = []
 
-    if os.getenv("system_prompt") and len(st.session_state.messages) == 0:
-        st.session_state.messages.append({"role": ROLE_SYSTEM, "content": os.getenv("system_prompt")})
+    if os.getenv("SYSTEM_PROMPT") and len(st.session_state.messages) == 0:
+        st.session_state.messages.append({"role": ROLE_SYSTEM, "content": os.getenv("SYSTEM_PROMPT")})
 
     if "messages_meta" not in st.session_state:
         st.session_state.messages_meta = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,19 +86,28 @@ def app_id():
 
 
 @pytest.fixture
-def app_base_url(
-    app_id
-):
+def app_base_url(app_id):
     return f"https://test-app.datarobot.com/custom_applications/{app_id}"
 
 
 @pytest.fixture
-def mock_set_env_app_name(
-        monkeypatch,
-        app_name,
-):
+def mock_set_env_app_name(monkeypatch, app_name):
     with patch.dict(os.environ):
-        monkeypatch.setenv("app_name", app_name)
+        monkeypatch.setenv("APP_NAME", app_name)
+        yield
+
+
+@pytest.fixture
+def mock_set_env_enable_enable_chat_api(monkeypatch, app_name):
+    with patch.dict(os.environ):
+        monkeypatch.setenv("ENABLE_CHAT_API", "true")
+        yield
+
+
+@pytest.fixture
+def mock_set_env_enable_enable_chat_api_streaming(monkeypatch, app_name):
+    with patch.dict(os.environ):
+        monkeypatch.setenv("ENABLE_CHAT_API_STREAMING", "true")
         yield
 
 
@@ -112,11 +121,11 @@ def mock_set_env(
     app_base_url,
 ):
     with patch.dict(os.environ, clear=True):
-        monkeypatch.setenv("token", datarobot_token)
-        monkeypatch.setenv("endpoint", datarobot_endpoint)
-        monkeypatch.setenv("custom_metric_id", custom_metric_id)
-        monkeypatch.setenv("deployment_id", deployment_id)
-        monkeypatch.setenv("app_base_url_path", app_base_url)
+        monkeypatch.setenv("TOKEN", datarobot_token)
+        monkeypatch.setenv("ENDPOINT", datarobot_endpoint)
+        monkeypatch.setenv("CUSTOM_METRIC_ID", custom_metric_id)
+        monkeypatch.setenv("DEPLOYMENT_ID", deployment_id)
+        monkeypatch.setenv("APP_BASE_URL_PATH", app_base_url)
         yield
 
 

--- a/tests/test_qa_chat_bot.py
+++ b/tests/test_qa_chat_bot.py
@@ -17,6 +17,7 @@ from .conftest import find_request_by_url, create_stream_chat_completion, create
 @pytest.mark.usefixtures(
     "mock_set_env",
     "mock_set_env_app_name",
+    "mock_set_env_enable_enable_chat_api",
     "mock_app_info_api",
     "mock_version_api",
     "mock_deployment_api",
@@ -26,7 +27,6 @@ from .conftest import find_request_by_url, create_stream_chat_completion, create
 @patch('constants.I18N_SPLASH_TITLE', 'What would you like to know?')
 @patch('constants.I18N_SPLASH_TEXT', 'Ask me anything!')
 @patch('constants.I18N_INPUT_PLACEHOLDER', 'Send your question')
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_empty_chat_app():
     # Path to the CSV file relative to the test file
     current_dir = os.path.dirname(__file__)
@@ -50,12 +50,12 @@ def test_empty_chat_app():
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_enable_enable_chat_api",
     "mock_app_info_api",
     "mock_version_api",
     "mock_deployment_api",
     "app_id"
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 def test_chat_api_supported_app():
     """The app loads and uses deployment capabilities to check for Chat API support"""
     at = AppTest.from_file("qa_chat_bot.py").run()
@@ -65,6 +65,7 @@ def test_chat_api_supported_app():
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_enable_enable_chat_api",
     "mock_app_info_api",
     "mock_deployment_api",
     "mock_version_api",
@@ -72,7 +73,6 @@ def test_chat_api_supported_app():
     "deployment_id",
     "datarobot_endpoint"
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch("openai.resources.chat.Completions.create")
 def test_chat_send_chat_api_error(openai_create, mock_bad_request_error, deployment_id, datarobot_endpoint):
     """The app receives chat response after sending a prompt"""
@@ -101,11 +101,11 @@ def test_chat_send_chat_api_error(openai_create, mock_bad_request_error, deploym
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_enable_enable_chat_api",
     "mock_app_info_api",
     "mock_deployment_api",
     "mock_version_api",
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch("openai.resources.chat.Completions.create")
 def test_chat_send_chat_api_without_stream_request(openai_create):
     """The app receives chat response after sending a prompt"""
@@ -159,11 +159,11 @@ def test_chat_send_chat_api_without_stream_request(openai_create):
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_enable_enable_chat_api",
     "mock_app_info_api",
     "mock_deployment_api",
     "mock_version_api",
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch("openai.resources.chat.Completions.create")
 def test_chat_api_no_citations(openai_create):
     """The app should not show citations button when not available"""
@@ -184,11 +184,11 @@ def test_chat_api_no_citations(openai_create):
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_enable_enable_chat_api",
     "mock_app_info_api",
     "mock_deployment_api",
     "mock_version_api",
 )
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch("openai.resources.chat.Completions.create")
 def test_chat_api_legacy_citations(openai_create):
     mock_file = 'mock_chat_api_no_stream_legacy_citations.json'
@@ -273,13 +273,12 @@ def test_chat_send_predict_request():
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_enable_enable_chat_api",
+    "mock_set_env_enable_enable_chat_api_streaming",
     "mock_app_info_api",
     "mock_deployment_api",
     "mock_version_api",
 )
-@patch('components.ENABLE_CHAT_API_STREAMING', True)
-@patch('constants.ENABLE_CHAT_API_STREAMING', True)
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch("openai.resources.chat.Completions.create")
 def test_chat_send_chat_api_stream_request(openai_create):
     """The app receives chat response after sending a prompt"""
@@ -330,6 +329,8 @@ def test_chat_send_chat_api_stream_request(openai_create):
 @responses.activate
 @pytest.mark.usefixtures(
     "mock_set_env",
+    "mock_set_env_enable_enable_chat_api",
+    "mock_set_env_enable_enable_chat_api_streaming",
     "mock_app_info_api",
     "mock_deployment_api",
     "mock_deployment_chat_api_stream",
@@ -339,8 +340,6 @@ def test_chat_send_chat_api_stream_request(openai_create):
     "is_model_specific"
 )
 @pytest.mark.parametrize("is_model_specific", [True, False])
-@patch('components.ENABLE_CHAT_API_STREAMING', True)
-@patch('constants.FORCE_DISABLE_CHAT_API', False)
 @patch("openai.resources.chat.Completions.create")
 def test_chat_feedback_request(openai_create, feedback_endpoint, model_id, is_model_specific):
     """The user can submit feedback for a response"""


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Make it easier for users to flip Chat API and streaming on/off by moving the values to runtime params

