### PR TITLE
[APP-3775] Bump app template version

### DIFF
--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.8"
+         "releaseTag": "11.0.9"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Bump to 11.0.9