### PR TITLE
[APP-3806] Improve Chat Api runtime param descriptions

### DIFF
--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -6,14 +6,14 @@ runtimeParameterDefinitions:
   type: string
 - fieldName: DEPLOYMENT_ID
   type: deployment
-- fieldName: SYSTEM_PROMPT
-  type: string
-  description: Replaces the system prompt set in Playground
 - fieldName: ENABLE_CHAT_API
   type: boolean
   defaultValue: False
-  description: Use Chat API if the deployment supports it
+  description: Use Chat API if the deployment supports it.
+- fieldName: SYSTEM_PROMPT
+  type: string
+  description: Replaces the system prompt set in Playground. Requires ENABLE_CHAT_API to be `True`.
 - fieldName: ENABLE_CHAT_API_STREAMING
   type: boolean
   defaultValue: False
-  description: Stream the response from Chat API
+  description: Stream the response from Chat API. Requires ENABLE_CHAT_API to be `True`.


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale
It wasnt clear that streaming and system prompt only work then chat api is enabled. Improve the descriptions for the params

