### PR TITLE
[APP-3824] Fix NoneType error for streaming response with None citations

### DIFF
--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -198,7 +198,7 @@ def send_chat_api_streaming_request(message):
                 yield content
             elif is_final_chunk:
                 try:
-                    if hasattr(chunk, 'citations'):
+                    if hasattr(chunk, 'citations') and chunk.citations is not None:
                         processed_citations = process_citations(chunk.citations)
 
                     if hasattr(chunk, 'datarobot_moderations'):

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.10"
+         "releaseTag": "11.0.11"
       },
       "previewImage": "qa-app-preview.png"
    },

--- a/tests/mocks/mock_final_chunk_no_citations.json
+++ b/tests/mocks/mock_final_chunk_no_citations.json
@@ -1,0 +1,21 @@
+{
+  "id": "8f467195-b4a7-4327-9f71-5f54a504329e",
+  "choices": [
+    {
+      "delta": {
+        "content": null,
+        "role": null
+      },
+      "finish_reason": "stop",
+      "index": 0
+    }
+  ],
+  "created": 1736949292,
+  "model": "DataRobot Moderation",
+  "object": "chat.completion.chunk",
+  "citations": null,
+  "llm_blueprint_id": "6759629338e0837a3d481683",
+  "llm_provider_guards": null,
+  "prompt_vector": [],
+  "datarobot_moderations": null
+}


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

When a deployment for Streaming Chat Api does not provide any citations, the process_citations step will fail.
It was fix and tested for non-streaming response but not for streaming

### Summary of Changes

Check citations before trying to process them.