### PR TITLE
[APP-3876] Set chat api model name to reserved DR name

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -8,6 +8,7 @@ DEFAULT_RESULT_COLUMN_NAME = 'resultText'
 
 # Chat API
 CHAT_CAPABILITIES_KEY = 'supports_chat_api'
+DEFAULT_CHAT_MODEL_NAME = 'datarobot-deployed-llm'
 
 # Timeouts
 CUSTOM_METRIC_SUBMIT_TIMEOUT_SECONDS = 60

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -20,7 +20,8 @@ from constants import (
     DEFAULT_PROMPT_COLUMN_NAME,
     DEFAULT_RESULT_COLUMN_NAME,
     CAPABILITIES_TIMEOUT_SECONDS,
-    CHAT_CAPABILITIES_KEY
+    CHAT_CAPABILITIES_KEY,
+    DEFAULT_CHAT_MODEL_NAME,
 )
 from utils import (
     get_deployment,
@@ -138,7 +139,6 @@ def send_predict_request(message):
 
 def send_chat_api_request(message):
     meta_id = message['meta_id']
-    deployment = get_deployment()
     base_url = get_base_url()
     openai_client = OpenAI(base_url=base_url, api_key=st.session_state.token)
 
@@ -146,7 +146,7 @@ def send_chat_api_request(message):
     extra_model_output = None
 
     with handle_chat_api_error(meta_id):
-        completion = openai_client.chat.completions.create(model=deployment.model.get("type"),
+        completion = openai_client.chat.completions.create(model=DEFAULT_CHAT_MODEL_NAME,
                                                            messages=sanitize_messages_for_request(
                                                                st.session_state.messages))
 
@@ -173,7 +173,6 @@ def send_chat_api_request(message):
 
 def send_chat_api_streaming_request(message):
     meta_id = message['meta_id']
-    deployment = get_deployment()
     base_url = get_base_url()
     openai_client = OpenAI(base_url=base_url, api_key=st.session_state.token)
 
@@ -182,7 +181,7 @@ def send_chat_api_streaming_request(message):
     aggregated_content = ""
 
     with handle_chat_api_error(meta_id):
-        streaming_response = openai_client.chat.completions.create(model=deployment.model.get("type"),
+        streaming_response = openai_client.chat.completions.create(model=DEFAULT_CHAT_MODEL_NAME,
                                                                    messages=sanitize_messages_for_request(
                                                                        st.session_state.messages),
                                                                    stream=True)

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.11"
+         "releaseTag": "11.0.12"
       },
       "previewImage": "qa-app-preview.png"
    },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,7 +373,7 @@ def create_chat_completion(mock_file):
 
         return ChatCompletion(
             id=mock_data.get("id"),
-            model=mock_data.get("model"),
+            model='datarobot-deployed-llm',
             object=mock_data.get("object"),
             choices=[
                 Choice(
@@ -408,7 +408,7 @@ def create_stream_chat_completion(chunk_files):
 
             yield ChatCompletionChunk(
                 id=chunk_data.get("id"),
-                model=chunk_data.get("model"),
+                model='datarobot-deployed-llm',
                 object=chunk_data.get("object"),
                 choices=[
                     StreamChoice(


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Going forward with new deployments users need to specify a valid model name to Chat API.
To keep the current functionality we need to set a reserved model name "datarobot-deployed-llm" which will select the baked-in default model name for the deployment

