### PR TITLE
[APP-4102] Fix association id for feedback custom metric

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -152,7 +152,8 @@ def response_info_footer(meta_id):
     feedback = message_meta['feedback_value']
     citations = message_meta.get('citations', None)
     custom_metric_id = st.session_state.custom_metric_id
-    association_id = get_association_id_column_name()
+    association_id_column_name = get_association_id_column_name()
+    association_id = message_meta.get(association_id_column_name, meta_id) if association_id_column_name else meta_id
 
     info_section_data = get_info_section_data(message_meta)
     has_info_data = len(info_section_data) > 0
@@ -168,14 +169,14 @@ def response_info_footer(meta_id):
                     btn_up_icon_class = 'feedback-up-icon-active' if feedback == 1 else 'feedback-up-icon'
                     with sal.button('feedback-button', btn_up_icon_class, container=col1):
                         # Uses thin blank “ ” (U+2009) to be visible
-                        col1.button(' ', on_click=submit_metric, args=(meta_id, message_meta, 1),
-                                    key=f"feedback-up-{meta_id}")
+                        col1.button(' ', on_click=submit_metric, args=(association_id, message_meta, 1),
+                                    key=f"feedback-up-{association_id}")
 
                     btn_down_icon_class = 'feedback-down-icon-active' if feedback == 0 else 'feedback-down-icon'
                     with sal.button('feedback-button', btn_down_icon_class, container=col1):
                         # Uses thin blank “ ” (U+2009) to be visible
-                        col1.button(' ', on_click=submit_metric, args=(meta_id, message_meta, 0),
-                                    key=f"feedback-down-{meta_id}")
+                        col1.button(' ', on_click=submit_metric, args=(association_id, message_meta, 0),
+                                    key=f"feedback-down-{association_id}")
                 if citations:
                     with sal.button('citation-button', container=col1):
                         col1.button(I18N_CITATION_BUTTON, key=f"citation-{meta_id}",

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -68,7 +68,7 @@ def prediction_server_override_url() -> Optional[str]:
         return None
 
 
-def submit_metric(meta_id, message_meta, value):
+def submit_metric(association_id, message_meta, value):
     deployment = get_deployment()
     endpoint = st.session_state.endpoint
     custom_metric_id = st.session_state.custom_metric_id
@@ -82,7 +82,7 @@ def submit_metric(meta_id, message_meta, value):
     url = f"{endpoint}/deployments/{deployment.id}/customMetrics/{custom_metric_id}/fromJSON/"
 
     ts = datetime.utcnow()
-    rows = [{"timestamp": ts.isoformat(), "value": value, "associationId": meta_id}]
+    rows = [{"timestamp": ts.isoformat(), "value": value, "associationId": association_id}]
     data = {
         "buckets": rows,
     }

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.13"
+         "releaseTag": "11.0.14"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

When assoc id was auto generated we continued to use a message meta id instead of the already generated association id. 

### Summary of Changes

- Attempt to use existing assoc id before falling back to message meta id