### PR TITLE
Enhance response_info_footer logic

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -157,7 +157,11 @@ def response_info_footer(meta_id):
 
     info_section_data = get_info_section_data(message_meta)
     has_info_data = len(info_section_data) > 0
-    if has_info_data or citations is not None:
+    if (
+        has_info_data
+        or citations is not None
+        or (custom_metric_id is not None and association_id is not None)
+    ):
         with sal.columns('chat-message-footer'):
             col0, col1 = st.columns([0.7, 0.3], vertical_alignment="center")
 

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.15"
+         "releaseTag": "11.3.0"
       },
       "previewImage": "qa-app-preview.png"
    },

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.0.14"
+         "releaseTag": "11.0.15"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## Rationale

Currently, if you are using a BYO LLM the feedback footer doesn't show up, even if the deployment and custom metric IDs are configured correctly.

### Summary of Changes

This PR will show the footer if there is both an association ID and a custom metric ID.