### PR TITLE
Bump main branch version to 11.2

### DIFF
--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.1.0"
+         "releaseTag": "11.2.0"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Bump main branch version for Q&A template, new release 11.1 branch has been created: 
https://github.com/datarobot-oss/qa-app-streamlit/tree/releases/11.1

