### PR TITLE
[APP-4672] Use another env var for app id -> app info call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Local dev files
+/.python-version
 /src/.python-version
 /src/start-app-local.sh
 /src/styles/sal-stylesheet.css

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Local dev files
-./styles/sal-stylesheet.css
-./src/start-app-local.sh
+/src/.python-version
+/src/start-app-local.sh
+/src/styles/sal-stylesheet.css
 
 # JetBrains IDE
 .idea

--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -216,8 +216,8 @@ def send_chat_api_streaming_request(message):
 
 @st.cache_data(show_spinner=False)
 def get_application_info():
-    if st.session_state.app_id is None:
-        # Fallback for local development
+    if st.session_state.app_id is None or st.session_state.app_id == "":
+        # Fallback for local development or invalid APP_ID
         return {}
 
     # Set HTTP headers. The charset should match the contents of the file.

--- a/src/start-app.sh
+++ b/src/start-app.sh
@@ -3,7 +3,7 @@ echo "Starting App"
 
 export TOKEN="$DATAROBOT_API_TOKEN"
 export ENDPOINT="$DATAROBOT_ENDPOINT"
-export APP_BASE_URL_PATH="$STREAMLIT_SERVER_BASE_URL_PATH"
+export APP_ID="$APPLICATION_ID"
 
 # If you have configured runtime params via DataRobots application source, the following 2 values should be set automatically.
 # Otherwise you will need to set DEPLOYMENT_ID (required) and CUSTOM_METRIC_ID (optional) manually

--- a/src/utils.py
+++ b/src/utils.py
@@ -73,9 +73,7 @@ def initiate_session_state():
     if 'deployment_id' not in st.session_state:
         st.session_state.deployment_id = os.getenv("DEPLOYMENT_ID")
     if 'app_id' not in st.session_state:
-        app_base_url_path = os.getenv("APP_BASE_URL_PATH")
-        st.session_state.app_id = app_base_url_path.split('/')[-1].strip() if app_base_url_path else None
-
+        st.session_state.app_id = os.getenv("APP_ID")
     if 'enable_chat_api' not in st.session_state:
         st.session_state.enable_chat_api = os.getenv("ENABLE_CHAT_API", 'False').lower() == 'true'
     if 'enable_chat_api_streaming' not in st.session_state:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,11 +86,6 @@ def app_id():
 
 
 @pytest.fixture
-def app_base_url(app_id):
-    return f"https://test-app.datarobot.com/custom_applications/{app_id}"
-
-
-@pytest.fixture
 def mock_set_env_app_name(monkeypatch, app_name):
     with patch.dict(os.environ):
         monkeypatch.setenv("APP_NAME", app_name)
@@ -118,14 +113,14 @@ def mock_set_env(
     datarobot_endpoint,
     custom_metric_id,
     deployment_id,
-    app_base_url,
+    app_id,
 ):
     with patch.dict(os.environ, clear=True):
         monkeypatch.setenv("TOKEN", datarobot_token)
         monkeypatch.setenv("ENDPOINT", datarobot_endpoint)
         monkeypatch.setenv("CUSTOM_METRIC_ID", custom_metric_id)
         monkeypatch.setenv("DEPLOYMENT_ID", deployment_id)
-        monkeypatch.setenv("APP_BASE_URL_PATH", app_base_url)
+        monkeypatch.setenv("APP_ID", app_id)
         yield
 
 


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Since june the split on STREAMLIT_SERVER_BASE_URL_PATH we used to get app_id no longer worked. There was a trailing slash added. Instead of splitting these things we can use the APPLICATION_ID added beginning of the year


_In general, what was changed? Screenshots are welcome too!_
