### PR TITLE
[APP-4012] Make sure we dont see duplicate responses for misconfigured NIM llm

### DIFF
--- a/src/dr_requests.py
+++ b/src/dr_requests.py
@@ -212,6 +212,7 @@ def send_chat_api_streaming_request(message):
                 set_result_message_state(meta_id, aggregated_content, status=STATUS_COMPLETED,
                                          citations=processed_citations,
                                          extra_model_output=extra_model_output)
+                return
 
 
 @st.cache_data(show_spinner=False)

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.2.0"
+         "releaseTag": "11.2.1"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

A user saw duplicate responses when using chat api + streaming, to guard against it we can make sure to return after the final chunk (finish_reason=stop)


_In general, what was changed? Screenshots are welcome too!_
