### PR TITLE
[APP-4762] Set new default True for Enable Chat API

### DIFF
--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -8,7 +8,7 @@ runtimeParameterDefinitions:
   type: deployment
 - fieldName: ENABLE_CHAT_API
   type: boolean
-  defaultValue: False
+  defaultValue: True
   description: Use Chat API if the deployment supports it.
 - fieldName: SYSTEM_PROMPT
   type: string

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.2.1"
+         "releaseTag": "11.2.2"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

Our support for Chat API has been out for a long time, set the default setting to True

