### PR TITLE
[APP-5821] Bump release tag

### DIFF
--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
       ],
       "source": {
          "repositoryUrl": "https://github.com/datarobot-oss/qa-app-streamlit",
-         "releaseTag": "11.8.2"
+         "releaseTag": "11.8.3"
       },
       "previewImage": "qa-app-preview.png"
    },


### PR DESCRIPTION
### Summary of Changes

Bump release tag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata change updating a version pointer; no code or runtime behavior changes in this repo.
> 
> **Overview**
> Bumps the `template_info.json` `templateMetadata.source.releaseTag` for the Q&A Chat Generation App from `11.8.2` to `11.8.3`, updating which upstream app release this template points to.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0defa38cf19ec21ab0d8dcc9df4913a318b8804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->